### PR TITLE
v0.2.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,10 +13,10 @@ builds:
 
         goos:
             - linux
-            - darwin
-            - windows
-            - freebsd
-            - solaris
+            # - darwin
+            # - windows
+            # - freebsd
+            # - solaris
 
         goarch:
             - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,10 +13,10 @@ builds:
 
         goos:
             - linux
-            # - darwin
-            # - windows
-            # - freebsd
-            # - solaris
+            - darwin
+            - windows
+            - freebsd
+            - solaris
 
         goarch:
             - amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.2.0
+    * add ability to create a [reverse] check - if a check bundle id is not provided for reverse, the agent will search for a suitable check bundle for the host. Previously, if a check bundle could not be found the agent would exit. Now, when `--reverse-create-check` is supplied, the agent has the ability to create a check, rather than exit.
+    * expose basic app stats endpoint /stats
 # v0.1.2
     * fix statsd packet channel (broken in v0.1.1)
     * update readme with current instructions

--- a/README.md
+++ b/README.md
@@ -59,16 +59,15 @@ Ensure that NAD is not currently running (e.g. `systemctl stop nad`) and start c
     1. `cd $GOPATH/src/github.com/circonus-labs`
     1. `git clone https://github.com/circonus-labs/circonus-agent.git`
     1. `cd circonus-agent && dep ensure`
-1. Build
+1. Build/Install
     1. `go build`
-1. Install
     1. `mkdir -p /opt/circonus/agent/sbin`
     1. `cp circonus-agent /opt/circonus/agent/sbin/circonus-agentd`
 1. Run
     1. `/opt/circonus/agent/sbin/circonus-agentd -h` for help
     1. example - on a system where cosi has *already* been run
        1. stop nad, if it is running
-       1. run: `/opt/circonus/agent/sbin/circonus-agentd -p /opt/circonus/nad/etc/node-agent.d -r -cid cosi -api-key cosi --log-pretty`
+       1. run: `/opt/circonus/agent/sbin/circonus-agentd -p /opt/circonus/nad/etc/node-agent.d -r --reverse-cid cosi --api-key cosi --log-pretty`
         * `-p` use the existing nad plugins
         * `--api-key cosi` load api credentials from cosi installation
         * `--reverse-cid cosi` load check information from cosi installation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd /opt/circonus
 mkdir -p agent/{sbin,etc}
 cd agent
 ln -s /opt/circonus/nad/etc/node-agent.d plugins
-curl "https://github.com/circonus-labs/circonus-agent/releases/download/v0.1.2/circonus-agent_0.1.2_linux_64-bit.tar.gz" -o circonus-agent.tgz
+curl -L "https://github.com/circonus-labs/circonus-agent/releases/download/v0.1.2/circonus-agent_0.1.2_linux_64-bit.tar.gz" -o circonus-agent.tgz
 tar zxf circonus-agent.tgz
 ```
 To leverage the existing COSI/NAD installation, create a configuration file `/opt/circonus/agent/etc/circonus-agent.toml` (or use the corresponding command line options.)
@@ -45,21 +45,14 @@ Ensure that NAD is not currently running (e.g. `systemctl stop nad`) and start c
 
 > NOTE: See `Vagrantfile` for an example which bootstraps a centos7 vm.
 
-1. Install go (on linux for example)
-    1. `curl "https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz" -O`
-    1. `sudo tar -C /usr/local -xzf go1.9.linux-amd64.tar.gz`
-    1. `echo 'export PATH="$PATH:/usr/local/go/bin"' > /etc/profile.d/go.sh` (root)
-1. Setup go env & clone repo
-    1. `mkdir -p ~/godev/src/github.com/circonus-labs`
-    1. Set `GOPATH="${HOME}/godev"` in `.bashrc`
-    1. Logout/login, verify `go version && env | grep GOPATH`
-1. Install dep (go package dependency manager)
-    1. `go get -u github.com/golang/dep/cmd/dep`
+1. Install and setup go environment
+    1. Install dep `go get -u github.com/golang/dep/cmd/dep`
 1. Clone repo and run dep
     1. `cd $GOPATH/src/github.com/circonus-labs`
     1. `git clone https://github.com/circonus-labs/circonus-agent.git`
-    1. `cd circonus-agent && dep ensure`
+    1. `cd circonus-agent`
 1. Build/Install
+    1.  `dep ensure`
     1. `go build`
     1. `mkdir -p /opt/circonus/agent/sbin`
     1. `cp circonus-agent /opt/circonus/agent/sbin/circonus-agentd`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## development working release - quick start
 
-Download latest release from repo [releases](https://github.com/circonus-labs/circonus-agent/releases).
+Download [latest release](https://github.com/circonus-labs/circonus-agent/releases/latest) from GitHub repository.
 
 Example of installing into an existing COSI registered linux system.
 
@@ -21,6 +21,7 @@ ln -s /opt/circonus/nad/etc/node-agent.d plugins
 curl -L "https://github.com/circonus-labs/circonus-agent/releases/download/v0.1.2/circonus-agent_0.1.2_linux_64-bit.tar.gz" -o circonus-agent.tgz
 tar zxf circonus-agent.tgz
 ```
+
 To leverage the existing COSI/NAD installation, create a configuration file `/opt/circonus/agent/etc/circonus-agent.toml` (or use the corresponding command line options.)
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > * No service configurations provided. (e.g. systemd, upstart, init, svc)
 > * Native plugins (.js) do not work. Unless modified to run `node` independently and follow [plugin output guidelines](#output).
 
-## development working release
+## development working release - quick start
 
 Download latest release from repo [releases](https://github.com/circonus-labs/circonus-agent/releases).
 
@@ -34,7 +34,9 @@ key = "cosi"
 
 Ensure that NAD is not currently running (e.g. `systemctl stop nad`) and start circonus-agent `sbin/circonus-agentd`.
 
-## development testing notes
+---
+
+## development testing (manual build/install from source)
 
 > NOTE: See `Vagrantfile` for an example which bootstraps a centos7 vm.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 > * No target specific packages. (e.g. rpm|deb|pkg)
 > * No service configurations provided. (e.g. systemd, upstart, init, svc)
 > * Native plugins (.js) do not work. Unless modified to run `node` independently and follow [plugin output guidelines](#output).
+>
+> The code is changing frequently at this point. Before reporting an issue, please ensure the [latest release](https://github.com/circonus-labs/circonus-agent/releases/latest) is being used.
 
 ## development working release - quick start
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ tar zxf circonus-agent.tgz
 To leverage the existing COSI/NAD installation, create a configuration file `/opt/circonus/agent/etc/circonus-agent.toml` (or use the corresponding command line options.)
 
 ```toml
+#debug = true
+
+# set the plugin directory to NAD's
+plugin-dir = "/opt/circonus/nad/etc/node-agent.d"
+
 [reverse]
 enabled = true
 cid = "cosi"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,10 +161,10 @@ func init() {
 			description = "Target host"
 		)
 
-		RootCmd.Flags().String(longOpt, defaults.Target, description)
+		RootCmd.Flags().String(longOpt, defaults.ReverseTarget, description)
 		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
 		viper.BindEnv(key, envVar)
-		viper.SetDefault(key, defaults.Target)
+		viper.SetDefault(key, defaults.ReverseTarget)
 
 	}
 
@@ -651,11 +651,15 @@ func Execute() {
 }
 
 func showConfig(w io.Writer) error {
-	var cfg interface{}
+	var cfg map[string]interface{}
 
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return errors.Wrap(err, "parsing config")
 	}
+
+	// these are pure flags (shouldn't be "in" config files)
+	delete(cfg, "version")
+	delete(cfg, "show-config")
 
 	data, err := json.MarshalIndent(cfg, " ", "  ")
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -170,6 +170,62 @@ func init() {
 
 	{
 		const (
+			key         = config.KeyReverseCreateCheck
+			longOpt     = "reverse-create-check"
+			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK"
+			description = "Create check if one cannot be found"
+		)
+
+		RootCmd.Flags().Bool(longOpt, defaults.ReverseCreateCheck, description)
+		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
+		viper.BindEnv(key, envVar)
+		viper.SetDefault(key, defaults.ReverseCreateCheck)
+	}
+
+	{
+		const (
+			key         = config.KeyReverseCreateCheckBroker
+			longOpt     = "reverse-create-check-broker"
+			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK_BROKER"
+			description = "Broker to use, if creating a check"
+		)
+
+		RootCmd.Flags().String(longOpt, defaults.ReverseCreateCheckBroker, description)
+		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
+		viper.BindEnv(key, envVar)
+		viper.SetDefault(key, defaults.ReverseCreateCheckBroker)
+	}
+
+	{
+		const (
+			key         = config.KeyReverseCreateCheckTitle
+			longOpt     = "reverse-create-check-title"
+			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK_TITLE"
+			description = "Title [display name] to use, if creating a check"
+		)
+
+		RootCmd.Flags().String(longOpt, defaults.ReverseCreateCheckTitle, description)
+		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
+		viper.BindEnv(key, envVar)
+		viper.SetDefault(key, defaults.ReverseCreateCheckTitle)
+	}
+
+	{
+		const (
+			key         = config.KeyReverseCreateCheckTags
+			longOpt     = "reverse-create-check-tags"
+			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK_TAGS"
+			description = "Tags [comma separated list] to use, if creating a check"
+		)
+
+		RootCmd.Flags().String(longOpt, defaults.ReverseCreateCheckTags, description)
+		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
+		viper.BindEnv(key, envVar)
+		viper.SetDefault(key, defaults.ReverseCreateCheckTags)
+	}
+
+	{
+		const (
 			key          = config.KeyReverseBrokerCAFile
 			longOpt      = "reverse-broker-ca-file"
 			defaultValue = ""

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,7 @@ func init() {
 			key         = config.KeyReverseCreateCheck
 			longOpt     = "reverse-create-check"
 			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK"
-			description = "Create check if one cannot be found"
+			description = "Create check bundle for reverse if one cannot be found"
 		)
 
 		RootCmd.Flags().Bool(longOpt, defaults.ReverseCreateCheck, description)
@@ -187,7 +187,7 @@ func init() {
 			key         = config.KeyReverseCreateCheckBroker
 			longOpt     = "reverse-create-check-broker"
 			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK_BROKER"
-			description = "Broker to use, if creating a check"
+			description = "ID of Broker to use or 'select' for random selection of valid broker, if creating a check bundle"
 		)
 
 		RootCmd.Flags().String(longOpt, defaults.ReverseCreateCheckBroker, description)
@@ -201,7 +201,7 @@ func init() {
 			key         = config.KeyReverseCreateCheckTitle
 			longOpt     = "reverse-create-check-title"
 			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK_TITLE"
-			description = "Title [display name] to use, if creating a check"
+			description = "Title [display name] to use, if creating a check bundle"
 		)
 
 		RootCmd.Flags().String(longOpt, defaults.ReverseCreateCheckTitle, description)
@@ -215,7 +215,7 @@ func init() {
 			key         = config.KeyReverseCreateCheckTags
 			longOpt     = "reverse-create-check-tags"
 			envVar      = release.ENVPREFIX + "_REVERSE_CREATE_CHECK_TAGS"
-			description = "Tags [comma separated list] to use, if creating a check"
+			description = "Tags [comma separated list] to use, if creating a check bundle"
 		)
 
 		RootCmd.Flags().String(longOpt, defaults.ReverseCreateCheckTags, description)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,7 +98,7 @@ func init() {
 			longOpt     = "listen"
 			shortOpt    = "l"
 			envVar      = release.ENVPREFIX + "_LISTEN"
-			description = "Listen address and port [[IP]:[PORT]]" + `(default "` + defaults.Listen + `")`
+			description = "Listen address and port [[IP]:[PORT]] " + `(default "` + defaults.Listen + `")`
 		)
 
 		RootCmd.Flags().StringP(longOpt, shortOpt, "", description)

--- a/internal/appstats/main.go
+++ b/internal/appstats/main.go
@@ -1,0 +1,159 @@
+// Copyright © 2017 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package appstats
+
+import (
+	"expvar"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	once  sync.Once
+	stats *expvar.Map
+)
+
+func init() {
+	once.Do(func() {
+		stats = expvar.NewMap("stats")
+	})
+}
+
+// NewString creates a new string stat
+func NewString(name string) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) != nil {
+		return errors.Errorf("stat (%s) already initialized", name)
+	}
+
+	stats.Set(name, new(expvar.String))
+
+	return nil
+}
+
+// SetString sets string stat to value
+func SetString(name string, value string) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) == nil {
+		NewString(name)
+	}
+
+	stats.Get(name).(*expvar.String).Set(value)
+
+	return nil
+}
+
+// NewInt creates a new int stat
+func NewInt(name string) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) != nil {
+		return errors.Errorf("stat (%s) already initialized", name)
+	}
+
+	stats.Set(name, new(expvar.Int))
+
+	return nil
+}
+
+// SetInt sets int stat to value
+func SetInt(name string, value int64) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) == nil {
+		NewInt(name)
+	}
+
+	stats.Get(name).(*expvar.Int).Set(value)
+
+	return nil
+}
+
+// IncrementInt increment int stat
+func IncrementInt(name string) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) == nil {
+		NewInt(name)
+	}
+
+	stats.Add(name, 1)
+
+	return nil
+}
+
+// DecrementInt decrement int stat
+func DecrementInt(name string) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) == nil {
+		NewInt(name)
+	}
+
+	stats.Add(name, -1)
+
+	return nil
+}
+
+// NewFloat creates a new float stat
+func NewFloat(name string) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) != nil {
+		return errors.Errorf("stat (%s) already initialized", name)
+	}
+
+	stats.Set(name, new(expvar.Float))
+
+	return nil
+}
+
+// SetFloat sets a float stat to value
+func SetFloat(name string, value float64) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) == nil {
+		NewFloat(name)
+	}
+
+	stats.Get(name).(*expvar.Float).Set(value)
+
+	return nil
+}
+
+// AddFloat adds value to existing float
+func AddFloat(name string, value float64) error {
+	if stats == nil {
+		return errors.Errorf("stats not initialized")
+	}
+
+	if stats.Get(name) == nil {
+		NewFloat(name)
+	}
+
+	stats.Get(name).(*expvar.Float).Add(value)
+
+	return nil
+}

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -32,10 +32,6 @@ func apiRequired() bool {
 }
 
 func validateAPIOptions() error {
-	if apiOK {
-		return nil
-	}
-
 	apiKey := viper.GetString(KeyAPITokenKey)
 	apiApp := viper.GetString(KeyAPITokenApp)
 	apiURL := viper.GetString(KeyAPIURL)
@@ -89,7 +85,6 @@ func validateAPIOptions() error {
 	viper.Set(KeyAPITokenKey, apiKey)
 	viper.Set(KeyAPITokenApp, apiApp)
 	viper.Set(KeyAPIURL, apiURL)
-	apiOK = true
 
 	return nil
 }

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -47,16 +47,6 @@ func TestValidateAPIOptions(t *testing.T) {
 		viper.Set(KeyStatsdDisabled, false)
 	}
 
-	t.Log("API already validated")
-	{
-		apiOK = true
-		err := validateAPIOptions()
-		if err != nil {
-			t.Fatal("Expected NO error")
-		}
-		apiOK = false
-	}
-
 	t.Log("No key/app/url")
 	{
 		expectedError := errors.New("API key is required")

--- a/internal/config/defaults/main.go
+++ b/internal/config/defaults/main.go
@@ -74,6 +74,19 @@ const (
 
 	// StatsdGroupSets defines how group counter metrics will be handled (average or sum)
 	StatsdGroupSets = "sum"
+
+	// ReverseCreateCheck flags whether a check, for reverse, should be created if one cannot be found
+	ReverseCreateCheck = false
+
+	// ReverseCreateCheckBroker to use if creating a check, 'select' or '' will
+	// result in the first broker which meets some basic criteria being selected.
+	// 1. Active status
+	// 2. Supports the required check type
+	// 3. Responds within reverse.brokerMaxResponseTime
+	ReverseCreateCheckBroker = "select"
+
+	// ReverseCreateCheckTags to use if creating a check (comma separated list)
+	ReverseCreateCheckTags = ""
 )
 
 var (
@@ -104,6 +117,9 @@ var (
 
 	// Target defaults to return from os.Hostname()
 	Target = ""
+
+	// ReverseCreateCheckTitle to use if creating a check
+	ReverseCreateCheckTitle = ""
 )
 
 func init() {
@@ -134,4 +150,6 @@ func init() {
 		fmt.Printf("Unable to determine hostname for target %v\n", err)
 		os.Exit(1)
 	}
+
+	ReverseCreateCheckTitle = Target + " /agent"
 }

--- a/internal/config/defaults/main.go
+++ b/internal/config/defaults/main.go
@@ -115,8 +115,8 @@ var (
 	// StatsdConf returns the default statsd config file
 	StatsdConf = "" // (e.g. /opt/circonus/agent/etc/statsd.json)
 
-	// Target defaults to return from os.Hostname()
-	Target = ""
+	// ReverseTarget defaults to return from os.Hostname()
+	ReverseTarget = ""
 
 	// ReverseCreateCheckTitle to use if creating a check
 	ReverseCreateCheckTitle = ""
@@ -145,11 +145,11 @@ func init() {
 	SSLCertFile = filepath.Join(EtcPath, release.NAME+".pem")
 	SSLKeyFile = filepath.Join(EtcPath, release.NAME+".key")
 
-	Target, err = os.Hostname()
+	ReverseTarget, err = os.Hostname()
 	if err != nil {
 		fmt.Printf("Unable to determine hostname for target %v\n", err)
 		os.Exit(1)
 	}
 
-	ReverseCreateCheckTitle = Target + " /agent"
+	ReverseCreateCheckTitle = ReverseTarget + " /agent"
 }

--- a/internal/config/structvar.go
+++ b/internal/config/structvar.go
@@ -60,6 +60,18 @@ const (
 	// KeyReverseTarget custom target|host to use for reverse (searching for a check) default os.Hostname()
 	KeyReverseTarget = "reverse.check_target"
 
+	// KeyReverseCreateCheck indicates whether a check should be created if one cannot be found for the target
+	KeyReverseCreateCheck = "reverse.create_check"
+
+	// KeyReverseCreateCheckBroker cid to use if creating a check
+	KeyReverseCreateCheckBroker = "reverse.check.broker"
+
+	// KeyReverseCreateCheckTitle to use if creating a check
+	KeyReverseCreateCheckTitle = "reverse.check.title"
+
+	// KeyReverseCreateCheckTags to add if creating a check
+	KeyReverseCreateCheckTags = "reverse.check.tags"
+
 	// KeyShowConfig - show configuration and exit
 	KeyShowConfig = "show-config"
 

--- a/internal/config/structvar.go
+++ b/internal/config/structvar.go
@@ -16,8 +16,6 @@ type cosiCheckConfig struct {
 }
 
 const (
-	cosiName = "cosi"
-
 	// KeyAPICAFile custom ca for circonus api (e.g. inside)
 	KeyAPICAFile = "api.ca_file"
 
@@ -116,9 +114,10 @@ const (
 
 	// KeyStatsdPort port for statsd listener (note, address will always be 'localhost')
 	KeyStatsdPort = "statsd.port"
+
+	cosiName = "cosi"
 )
 
 var (
-	apiOK       = false
 	cosiCfgFile = filepath.Join(defaults.BasePath, "..", cosiName, "etc", "cosi.json")
 )

--- a/internal/plugins/scan.go
+++ b/internal/plugins/scan.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/circonus-labs/circonus-agent/internal/appstats"
 	"github.com/circonus-labs/circonus-agent/internal/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -42,6 +43,8 @@ func (p *Plugins) Scan() error {
 	if err := p.Stop(); err != nil {
 		return errors.Wrap(err, "stopping plugin(s)")
 	}
+
+	appstats.SetInt("plugins_total", 0)
 
 	if err := p.scanPluginDirectory(); err != nil {
 		return errors.Wrap(err, "plugin directory scan")
@@ -194,6 +197,7 @@ func (p *Plugins) scanPluginDirectory() error {
 				plug = p.active[fileBase]
 			}
 
+			appstats.IncrementInt("plugins_total")
 			plug.Generation = p.generation
 			plug.Command = cmdName
 			p.logger.Info().
@@ -219,6 +223,7 @@ func (p *Plugins) scanPluginDirectory() error {
 					plug = p.active[pluginName]
 				}
 
+				appstats.IncrementInt("plugins_total")
 				plug.Generation = p.generation
 				plug.Command = cmdName
 				p.logger.Info().

--- a/internal/release/main.go
+++ b/internal/release/main.go
@@ -1,0 +1,24 @@
+// Copyright © 2017 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package release
+
+import (
+	"expvar"
+)
+
+func init() {
+	expvar.Publish("app", expvar.Func(info))
+}
+
+func info() interface{} {
+	return &Info{
+		Name:      NAME,
+		Version:   VERSION,
+		Commit:    COMMIT,
+		BuildDate: DATE,
+		Tag:       TAG,
+	}
+}

--- a/internal/release/vars.go
+++ b/internal/release/vars.go
@@ -23,3 +23,12 @@ var (
 	// VERSION of the release
 	VERSION = "dev"
 )
+
+// Info contains release information
+type Info struct {
+	Name      string
+	Version   string
+	Commit    string
+	BuildDate string
+	Tag       string
+}

--- a/internal/reverse/structvar.go
+++ b/internal/reverse/structvar.go
@@ -66,14 +66,17 @@ type connError struct {
 
 const (
 	// NOTE: TBD, make some of these user-configurable
-	commTimeoutSeconds   = 65        // seconds, when communicating with noit
-	dialerTimeoutSeconds = 15        // seconds, establishing connection
-	metricTimeoutSeconds = 50        // seconds, when communicating with agent
-	maxPayloadLen        = 65529     // max unsigned short - 6 (for header)
-	maxConnRetry         = 10        // max times to retry a persistently failing connection
-	configRetryLimit     = 5         // if failed attempts > threshold, force reconfig
-	maxDelaySeconds      = 60        // maximum amount of delay between attempts
-	minDelayStep         = 1         // minimum seconds to add on retry
-	maxDelayStep         = 20        // maximum seconds to add on retry
-	noitCmdConnect       = "CONNECT" // command from noit/broker
+	commTimeoutSeconds    = 65        // seconds, when communicating with noit
+	dialerTimeoutSeconds  = 15        // seconds, establishing connection
+	metricTimeoutSeconds  = 50        // seconds, when communicating with agent
+	maxPayloadLen         = 65529     // max unsigned short - 6 (for header)
+	maxConnRetry          = 10        // max times to retry a persistently failing connection
+	configRetryLimit      = 5         // if failed attempts > threshold, force reconfig
+	maxDelaySeconds       = 60        // maximum amount of delay between attempts
+	minDelayStep          = 1         // minimum seconds to add on retry
+	maxDelayStep          = 20        // maximum seconds to add on retry
+	noitCmdConnect        = "CONNECT" // command from noit/broker
+	brokerMaxRetries      = 5
+	brokerMaxResponseTime = 500 * time.Millisecond
+	brokerActiveStatus    = "active"
 )

--- a/internal/statsd/main.go
+++ b/internal/statsd/main.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"regexp"
 
+	"github.com/circonus-labs/circonus-agent/internal/appstats"
 	"github.com/circonus-labs/circonus-agent/internal/config"
 	cgm "github.com/circonus-labs/circonus-gometrics"
 	"github.com/pkg/errors"
@@ -204,6 +205,7 @@ func (s *Server) reader() error {
 			return errors.Wrap(err, "reader")
 		}
 		if n > 0 {
+			appstats.IncrementInt("statsd_packets_total")
 			pkt := make([]byte, n)
 			copy(pkt, buff[:n])
 			s.packetCh <- pkt
@@ -221,6 +223,7 @@ func (s *Server) processor() error {
 		case pkt := <-s.packetCh:
 			err := s.processPacket(pkt)
 			if err != nil {
+				appstats.IncrementInt("statsd_packets_bad")
 				s.logger.Error().Err(err).Msg("processor")
 				return errors.Wrap(err, "processor")
 			}

--- a/internal/statsd/metrics.go
+++ b/internal/statsd/metrics.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/circonus-labs/circonus-agent/internal/appstats"
 	cgm "github.com/circonus-labs/circonus-gometrics"
 	"github.com/pkg/errors"
 )
@@ -24,6 +25,7 @@ func (s *Server) processPacket(pkt []byte) error {
 	metrics := bytes.Split(pkt, []byte("\n"))
 	for _, metric := range metrics {
 		if err := s.parseMetric(string(metric)); err != nil {
+			appstats.IncrementInt("statsd_metrics_bad")
 			s.logger.Warn().Err(err).Str("metric", string(metric)).Msg("parsing")
 		}
 	}


### PR DESCRIPTION
    * add ability to create a [reverse] check - if a check bundle id is not provided for reverse, the agent will search for a suitable check bundle for the host. Previously, if a check bundle could not be found the agent would exit. Now, when `--reverse-create-check` is supplied, the agent has the ability to create a check, rather than exit.
    * expose basic app stats endpoint /stats
