### PR TITLE
v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.9.1
+
+* upd: constrain IDs provided in /run and /write URLs to [a-zA-Z0-9-]; ensure clean metric name prefixes
+* fix: make plugins optional, do _not_ fatal error if no plugins are found
+
 # v0.9.0
 
 * add: initial mvp prometheus collector (pull prometheus text formatted metrics from an endpoint)

--- a/internal/plugins/scan.go
+++ b/internal/plugins/scan.go
@@ -274,7 +274,7 @@ func (p *Plugins) scanPluginDirectory(b *builtins.Builtins) error {
 	}
 
 	if len(p.active) == 0 {
-		return errors.New("No active plugins found")
+		p.logger.Warn().Msg("no active plugins found")
 	}
 
 	return nil

--- a/internal/server/vars.go
+++ b/internal/server/vars.go
@@ -58,9 +58,9 @@ type previousMetrics struct {
 }
 
 var (
-	pluginPathRx    = regexp.MustCompile("^/(run(/.*)?)?$")
+	pluginPathRx    = regexp.MustCompile("^/(run(/[a-zA-Z0-9-]*)?)?$")
 	inventoryPathRx = regexp.MustCompile("^/inventory/?$")
-	writePathRx     = regexp.MustCompile("^/write/.+$")
+	writePathRx     = regexp.MustCompile("^/write/[a-zA-Z0-9-]+$")
 	statsPathRx     = regexp.MustCompile("^/stats/?$")
 	promPathRx      = regexp.MustCompile("^/prom/?$")
 	lastMetrics     = &previousMetrics{}


### PR DESCRIPTION
* upd: constrain IDs provided in /run and /write URLs to [a-zA-Z0-9-]; ensure clean metric name prefixes
* fix: make plugins optional, do _not_ fatal error if no plugins are found
