### PR TITLE
v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.15.0
+
+* add: check bundle id to all reverse log messages
+* upd: fatal when errors starting main listening servers (e.g. address already in use)
+* upd: add more debug lines around refreshing check configuration
+* fix: lock contention when refreshing check configuration for reverse AND enable new metrics is active
+* add: `--reverse-max-conn-retry` command line option
+* wip: gate max requests from broker before forced reset
+* wip: refactor of inventory endpoint
+* upd: cosi v2 prep
+
 # v0.14.1
 
 * upd: io latency plugin for linux - add additional signals to handler and cleanup in tracing start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.15.0
 
+* mrg: tracking upstream
 * add: check bundle id to all reverse log messages
 * upd: fatal when errors starting main listening servers (e.g. address already in use)
 * upd: add more debug lines around refreshing check configuration

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -202,6 +202,20 @@ func init() {
 		viper.BindEnv(key, envVar)
 	}
 
+	{
+		const (
+			key          = config.KeyReverseMaxConnRetry
+			longOpt      = "reverse-max-conn-retry"
+			defaultValue = defaults.ReverseMaxConnRetry
+			envVar       = release.ENVPREFIX + "_REVERSE_MAX_CONN_RETRY"
+			description  = "Max attempts to retry persistently failing reverse connection to broker [-1=indefinitely]"
+		)
+
+		RootCmd.Flags().Int(longOpt, defaultValue, desc(description, envVar))
+		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
+		viper.BindEnv(key, envVar)
+	}
+
 	//
 	// Check
 	//

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -56,8 +56,11 @@ func (c *Check) setCheck() error {
 		return errors.New("invalid Check object state, bundle is nil")
 	}
 
+	c.Lock()
 	c.bundle = bundle
+	c.Unlock()
 	if isManaged {
+		c.logger.Debug().Msg("setting metric states")
 		err := c.setMetricStates(&bundle.Metrics)
 		if err != nil {
 			return errors.Wrap(err, "setting metric states")
@@ -66,15 +69,19 @@ func (c *Check) setCheck() error {
 
 	// the metrics from the reference bundle are not needed in memory
 	// as they will never be used again.
+	c.Lock()
 	c.bundle.Metrics = []api.CheckBundleMetric{}
+	c.Unlock()
 
 	if isReverse {
 		// populate reverse configuration
+		c.logger.Debug().Msg("setting reverse config")
 		err := c.setReverseConfig()
 		if err != nil {
 			return errors.Wrap(err, "setting up reverse configuration")
 		}
 	}
+	c.logger.Debug().Msg("done updating check")
 
 	return nil
 }

--- a/internal/check/main.go
+++ b/internal/check/main.go
@@ -126,20 +126,21 @@ func New(apiClient API) (*Check, error) {
 
 // RefreshCheckConfig re-loads the check bundle using the API and reconfigures reverse (if needed)
 func (c *Check) RefreshCheckConfig() error {
-	c.Lock()
-	defer c.Unlock()
+	// c.Lock()
+	// defer c.Unlock()
+	c.logger.Debug().Msg("refreshing check configuration using API")
 	return c.setCheck()
 }
 
 // GetReverseConfig returns the reverse configuration to use for the broker
-func (c *Check) GetReverseConfig() (ReverseConfig, error) {
+func (c *Check) GetReverseConfig() (*ReverseConfig, error) {
 	c.Lock()
 	defer c.Unlock()
 
 	if c.revConfig == nil {
-		return ReverseConfig{}, errors.New("invalid reverse configuration")
+		return nil, errors.New("invalid reverse configuration")
 	}
-	return *c.revConfig, nil
+	return c.revConfig, nil
 }
 
 // EnableNewMetrics updates the check bundle enabling any new metrics

--- a/internal/check/state.go
+++ b/internal/check/state.go
@@ -16,7 +16,8 @@ import (
 )
 
 func (c *Check) setMetricStates(m *[]api.CheckBundleMetric) error {
-	c.logger.Debug().Msg("updating metric states")
+	c.Lock()
+	defer c.Unlock()
 
 	if m == nil {
 		metrics, err := c.getFullCheckMetrics()

--- a/internal/config/defaults/main.go
+++ b/internal/config/defaults/main.go
@@ -48,6 +48,9 @@ const (
 	// Watch plugins for changes
 	Watch = false
 
+	// ReverseMaxConnRetry - how many times to retry persistently failing broker connection
+	ReverseMaxConnRetry = 10
+
 	// StatsdPort to listen, NOTE address is always localhost
 	StatsdPort = "8125"
 

--- a/internal/config/vars.go
+++ b/internal/config/vars.go
@@ -49,6 +49,7 @@ type Check struct {
 type Reverse struct {
 	BrokerCAFile string `mapstructure:"broker_ca_file" json:"broker_ca_file" yaml:"broker_ca_file" toml:"broker_ca_file"`
 	Enabled      bool   `json:"enabled" yaml:"enabled" toml:"enabled"`
+	MaxConnRetry int    `mapstructure:"max_conn_retry" json:"max_conn_retry" yaml:"max_conn_retry" toml:"max_conn_retry"`
 }
 
 // SSL defines the running config.ssl structure
@@ -154,6 +155,9 @@ const (
 
 	// KeyReverseBrokerCAFile custom broker ca file
 	KeyReverseBrokerCAFile = "reverse.broker_ca_file"
+
+	// KeyReverseMaxConnRetry how many times to retry a persistently failing broker connection. default 10, -1 = indefinitely
+	KeyReverseMaxConnRetry = "reverse.max_conn_retry"
 
 	// KeyShowConfig - show configuration and exit
 	KeyShowConfig = "show-config"

--- a/internal/plugins/main.go
+++ b/internal/plugins/main.go
@@ -200,11 +200,10 @@ func (p *Plugins) IsInternal(pluginName string) bool {
 func (p *Plugins) Inventory() []byte {
 	p.Lock()
 	defer p.Unlock()
-	// inventory := make(map[string]*pluginDetails, len(p.active))
-	inventory := make(api.Inventory, 0, len(p.active))
+	inventory := api.Inventory{}
 	for id, plug := range p.active {
 		plug.Lock()
-		p := api.Plugin{
+		pinfo := api.Plugin{
 			ID:              id,
 			Name:            plug.id,
 			Instance:        plug.instanceID,
@@ -215,11 +214,10 @@ func (p *Plugins) Inventory() []byte {
 			LastRunDuration: plug.lastRunDuration.String(),
 		}
 		if plug.lastError != nil {
-			p.LastError = plug.lastError.Error()
+			pinfo.LastError = plug.lastError.Error()
 		}
 		plug.Unlock()
-
-		inventory = append(inventory, p)
+		inventory = append(inventory, pinfo)
 	}
 	data, err := json.Marshal(inventory)
 	if err != nil {

--- a/internal/reverse/connection.go
+++ b/internal/reverse/connection.go
@@ -120,7 +120,7 @@ func (c *Connection) connect() (*tls.Conn, *connError) {
 	dialer := &net.Dialer{Timeout: c.dialerTimeout}
 	conn, err := tls.DialWithDialer(dialer, "tcp", c.revConfig.BrokerAddr.String(), c.revConfig.TLSConfig)
 	if err != nil {
-		if c.connAttempts >= c.maxConnRetry {
+		if c.maxConnRetry != -1 && c.connAttempts >= c.maxConnRetry {
 			return nil, &connError{fatal: true, err: errors.Wrapf(err, "after %d failed attempts, last error", c.connAttempts)}
 		}
 		return nil, &connError{fatal: false, err: errors.Wrapf(err, "connecting to %s", revHost)}

--- a/internal/reverse/connection.go
+++ b/internal/reverse/connection.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/circonus-labs/circonus-agent/internal/config"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
 
@@ -115,6 +116,7 @@ func (c *Connection) connect() (*tls.Conn, *connError) {
 				return nil, &connError{fatal: true, err: errors.Wrap(err, "invalid reverse configuration (nil)")}
 			}
 			c.revConfig = *rc
+			c.logger = log.With().Str("pkg", "reverse").Str("cid", viper.GetString(config.KeyCheckBundleID)).Logger()
 			c.logger.Info().
 				Str("check_bundle", viper.GetString(config.KeyCheckBundleID)).
 				Str("rev_host", c.revConfig.ReverseURL.Hostname()).

--- a/internal/reverse/connection_test.go
+++ b/internal/reverse/connection_test.go
@@ -179,6 +179,7 @@ func TestConnect(t *testing.T) {
 			},
 		}
 		s.dialerTimeout = 2 * time.Second
+		s.maxConnRetry = 10
 
 		expect := errors.Errorf("connecting to %s: tls: DialWithDialer timed out", l.Addr().String())
 
@@ -231,6 +232,7 @@ func TestConnect(t *testing.T) {
 			},
 		}
 		s.dialerTimeout = 2 * time.Second
+		s.maxConnRetry = 10
 
 		if _, cerr := s.connect(); cerr == nil {
 			t.Fatal("expected error")

--- a/internal/reverse/main.go
+++ b/internal/reverse/main.go
@@ -36,6 +36,7 @@ func New(check *check.Check, agentAddress string) (*Connection, error) {
 		dialerTimeoutSeconds  = 15 // seconds, establishing connection
 		metricTimeoutSeconds  = 50 // seconds, when communicating with agent
 		maxDelaySeconds       = 60 // maximum amount of delay between attempts
+		maxRequests           = -1 // max requests from broker before resetting connection, -1 = unlimited
 		brokerMaxRetries      = 5
 		brokerMaxResponseTime = 500 * time.Millisecond
 		brokerActiveStatus    = "active"
@@ -60,12 +61,13 @@ func New(check *check.Check, agentAddress string) (*Connection, error) {
 		metricTimeout:    metricTimeoutSeconds * time.Second,
 		cmdConnect:       "CONNECT",
 		cmdReset:         "RESET",
-		maxPayloadLen:    65529, // max unsigned short - 6 (for header)
-		maxCommTimeouts:  5,     // multiply by commTimeout, ensure >(broker polling interval) otherwise conn reset loop
-		minDelayStep:     1,     // minimum seconds to add on retry
-		maxDelayStep:     20,    // maximum seconds to add on retry
-		maxConnRetry:     10,    // max times to retry a persistently failing connection
-		configRetryLimit: 5,     // if failed attempts > threshold, force reconfig
+		maxPayloadLen:    65529,                                       // max unsigned short - 6 (for header)
+		maxCommTimeouts:  5,                                           // multiply by commTimeout, ensure >(broker polling interval) otherwise conn reset loop
+		minDelayStep:     1,                                           // minimum seconds to add on retry
+		maxDelayStep:     20,                                          // maximum seconds to add on retry
+		maxConnRetry:     viper.GetInt(config.KeyReverseMaxConnRetry), // max times to retry a persistently failing connection
+		configRetryLimit: 5,                                           // if failed attempts > threshold, force reconfig
+		maxRequests:      maxRequests,                                 // max requests from broker before reset
 	}
 
 	if c.enabled {

--- a/internal/reverse/main.go
+++ b/internal/reverse/main.go
@@ -76,7 +76,10 @@ func New(check *check.Check, agentAddress string) (*Connection, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "setting reverse config")
 		}
-		c.revConfig = rc
+		if rc == nil {
+			return nil, errors.New("invalid reverse configuration (nil)")
+		}
+		c.revConfig = *rc
 	}
 
 	return &c, nil

--- a/internal/reverse/main.go
+++ b/internal/reverse/main.go
@@ -82,6 +82,8 @@ func New(check *check.Check, agentAddress string) (*Connection, error) {
 		c.revConfig = *rc
 	}
 
+	c.logger = log.With().Str("pkg", "reverse").Str("cid", viper.GetString(config.KeyCheckBundleID)).Logger()
+
 	return &c, nil
 }
 

--- a/internal/reverse/metrics.go
+++ b/internal/reverse/metrics.go
@@ -48,6 +48,13 @@ func (c *Connection) sendMetricData(r io.Writer, channelID uint16, data *[]byte)
 		Int("bytes", len(*data)).
 		Msg("metric data sent")
 
+	if c.maxRequests != -1 && channelID > uint16(c.maxRequests) {
+		if conn, ok := r.(*tls.Conn); ok {
+			c.logger.Info().Uint16("channel", channelID).Int("max", c.maxRequests).Msg("resetting connection")
+			conn.Close()
+		}
+	}
+
 	return nil
 }
 

--- a/internal/reverse/vars.go
+++ b/internal/reverse/vars.go
@@ -34,6 +34,7 @@ type Connection struct {
 	maxDelay         time.Duration
 	maxDelayStep     int
 	maxPayloadLen    uint32
+	maxRequests      int
 	metricTimeout    time.Duration
 	minDelayStep     int
 	revConfig        check.ReverseConfig

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -238,9 +238,10 @@ func (s *Server) startHTTP(svr *httpServer) error {
 	s.logger.Info().Str("listen", svr.address.String()).Msg("Starting")
 	if err := svr.server.ListenAndServe(); err != nil {
 		if err != http.ErrServerClosed {
-			s.logger.Error().Err(err).Msg("HTTP Server, stopping agent")
+			s.logger.Fatal().Err(err).Msg("HTTP Server, stopping agent")
 			return errors.Wrap(err, "HTTP server")
 		}
+
 	}
 	return nil
 }
@@ -253,7 +254,7 @@ func (s *Server) startHTTPS() error {
 	s.logger.Info().Str("listen", s.svrHTTPS.server.Addr).Msg("SSL starting")
 	if err := s.svrHTTPS.server.ListenAndServeTLS(s.svrHTTPS.certFile, s.svrHTTPS.keyFile); err != nil {
 		if err != http.ErrServerClosed {
-			s.logger.Error().Err(err).Msg("SSL Server, stopping agent")
+			s.logger.Fatal().Err(err).Msg("SSL Server, stopping agent")
 			return errors.Wrap(err, "SSL server")
 		}
 	}
@@ -277,7 +278,7 @@ func (s *Server) startSocket(svr *socketServer) error {
 	s.logger.Info().Str("listen", svr.address.String()).Msg("Socket starting")
 	if err := svr.server.Serve(svr.listener); err != nil {
 		if err != http.ErrServerClosed {
-			s.logger.Error().Err(err).Str("socket", svr.address.String()).Msg("Socket Server, stopping agent")
+			s.logger.Fatal().Err(err).Str("socket", svr.address.String()).Msg("Socket Server, stopping agent")
 			return errors.Wrap(err, "socket server")
 		}
 	}


### PR DESCRIPTION
* mrg: tracking upstream
* add: check bundle id to all reverse log messages
* upd: fatal when errors starting main listening servers (e.g. address already in use)
* upd: add more debug lines around refreshing check configuration
* fix: lock contention when refreshing check configuration for reverse AND enable new metrics is active
* add: `--reverse-max-conn-retry` command line option
* wip: gate max requests from broker before forced reset
* wip: refactor of inventory endpoint
* upd: cosi v2 prep
