### PR TITLE
v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.16.0
+
+* fix: add error to reset command result so it is honored
+* fix: remove deadlock in setReverseConfig
+* upd: revert max reverse conn retries back to infinite (-1)
+* upd: switch server request logging to debug level
+* fix: handle enable new metrics when there's an error with the state directory. Disable new metric enabling and turn off check management, but allow check to be created.
+* upd: export plugin/builtin stat times as strings for json
+
 # v0.15.1
 
 * fix: lock contention in check refresh

--- a/internal/builtins/configure.go
+++ b/internal/builtins/configure.go
@@ -15,11 +15,13 @@ import (
 func (b *Builtins) configure() error {
 	prom, err := prometheus.New("")
 	if err != nil {
-		appstats.MapAddInt("builtins", "total", 0)
+		appstats.AddInt("builtins.total", 0)
+		// appstats.MapAddInt("builtins", "total", 0)
 		b.logger.Warn().Err(err).Msg("prom collector, disabling")
 	} else {
 		b.collectors[prom.ID()] = prom
-		appstats.MapIncrementInt("builtins", "total")
+		appstats.IncrementInt("builtins.total")
+		// appstats.MapIncrementInt("builtins", "total")
 	}
 	return nil
 }

--- a/internal/builtins/configure_linux.go
+++ b/internal/builtins/configure_linux.go
@@ -23,7 +23,8 @@ func (b *Builtins) configure() error {
 		return err
 	}
 	for _, c := range collectors {
-		appstats.MapIncrementInt("builtins", "total")
+		appstats.IncrementInt("builtins.total")
+		// appstats.MapIncrementInt("builtins", "total")
 		b.logger.Info().Str("id", c.ID()).Msg("enabled builtin")
 		b.collectors[c.ID()] = c
 	}
@@ -31,7 +32,8 @@ func (b *Builtins) configure() error {
 	if err != nil {
 		b.logger.Warn().Err(err).Msg("prom collector, disabling")
 	} else {
-		appstats.MapIncrementInt("builtins", "total")
+		appstats.IncrementInt("builtins.total")
+		// appstats.MapIncrementInt("builtins", "total")
 		b.collectors[prom.ID()] = prom
 	}
 	return nil

--- a/internal/builtins/configure_windows.go
+++ b/internal/builtins/configure_windows.go
@@ -23,7 +23,8 @@ func (b *Builtins) configure() error {
 		return err
 	}
 	for _, c := range collectors {
-		appstats.MapIncrementInt("builtins", "total")
+		appstats.IncrementInt("builtins.total")
+		// appstats.MapIncrementInt("builtins", "total")
 		b.logger.Info().Str("id", c.ID()).Msg("enabled builtin")
 		b.collectors[c.ID()] = c
 	}
@@ -31,7 +32,8 @@ func (b *Builtins) configure() error {
 	if err != nil {
 		b.logger.Warn().Err(err).Msg("prom collector, disabling")
 	} else {
-		appstats.MapIncrementInt("builtins", "total")
+		appstats.IncrementInt("builtins.total")
+		// appstats.MapIncrementInt("builtins", "total")
 		b.collectors[prom.ID()] = prom
 	}
 	return nil

--- a/internal/builtins/main.go
+++ b/internal/builtins/main.go
@@ -53,7 +53,8 @@ func (b *Builtins) Run(id string) error {
 	b.Unlock()
 
 	start := time.Now()
-	appstats.MapSet("builtins", "last_start", start)
+	appstats.SetString("builtins.last_start", start.String())
+	// appstats.MapSet("builtins", "last_start", start)
 
 	var wg sync.WaitGroup
 
@@ -90,8 +91,10 @@ func (b *Builtins) Run(id string) error {
 
 	b.logger.Debug().Msg("all builtins done")
 
-	appstats.MapSet("builtins", "last_end", time.Now())
-	appstats.MapSet("builtins", "last_duration", time.Since(start))
+	appstats.SetString("builtins.last_end", time.Now().String())
+	appstats.SetString("builtins.last_duration", time.Since(start).String())
+	// appstats.MapSet("builtins", "last_end", time.Now())
+	// appstats.MapSet("builtins", "last_duration", time.Since(start))
 
 	b.Lock()
 	b.running = false
@@ -123,7 +126,8 @@ func (b *Builtins) Flush(id string) *cgm.Metrics {
 	b.Lock()
 	defer b.Unlock()
 
-	appstats.MapSet("builtins", "last_flush", time.Now())
+	appstats.SetString("builtins.last_flush", time.Now().String())
+	// appstats.MapSet("builtins", "last_flush", time.Now())
 
 	metrics := cgm.Metrics{}
 

--- a/internal/check/broker.go
+++ b/internal/check/broker.go
@@ -26,9 +26,6 @@ import (
 )
 
 func (c *Check) setReverseConfig() error {
-	c.Lock()
-	defer c.Unlock()
-
 	if len(c.bundle.ReverseConnectURLs) == 0 {
 		return errors.New("no reverse URLs found in check bundle")
 	}

--- a/internal/config/defaults/main.go
+++ b/internal/config/defaults/main.go
@@ -49,7 +49,7 @@ const (
 	Watch = false
 
 	// ReverseMaxConnRetry - how many times to retry persistently failing broker connection
-	ReverseMaxConnRetry = 10
+	ReverseMaxConnRetry = -1
 
 	// StatsdPort to listen, NOTE address is always localhost
 	StatsdPort = "8125"

--- a/internal/plugins/main.go
+++ b/internal/plugins/main.go
@@ -80,7 +80,8 @@ func (p *Plugins) Flush(pluginName string) *cgm.Metrics {
 	p.RLock()
 	defer p.RUnlock()
 
-	appstats.MapSet("plugins", "last_flush", time.Now())
+	appstats.SetString("plugins.last_flush", time.Now().String())
+	// appstats.MapSet("plugins", "last_flush", time.Now())
 
 	metrics := cgm.Metrics{}
 
@@ -117,7 +118,8 @@ func (p *Plugins) Run(pluginName string) error {
 	}
 
 	start := time.Now()
-	appstats.MapSet("plugins", "last_run_start", start)
+	appstats.SetString("plugins.last_run_start", start.String())
+	// appstats.MapSet("plugins", "last_run_start", start)
 
 	p.running = true
 	p.Unlock()
@@ -156,8 +158,10 @@ func (p *Plugins) Run(pluginName string) error {
 
 	wg.Wait()
 
-	appstats.MapSet("plugins", "last_run_end", time.Now())
-	appstats.MapSet("plugins", "last_run_duration", time.Since(start))
+	appstats.SetString("plugins.last_run_end", time.Now().String())
+	appstats.SetString("plugins.last_run_duration", time.Since(start).String())
+	// appstats.MapSet("plugins", "last_run_end", time.Now())
+	// appstats.MapSet("plugins", "last_run_duration", time.Since(start))
 
 	p.Lock()
 	p.running = false

--- a/internal/plugins/scan.go
+++ b/internal/plugins/scan.go
@@ -237,7 +237,8 @@ func (p *Plugins) scanPluginDirectory(b *builtins.Builtins) error {
 				plug = p.active[fileBase]
 			}
 
-			appstats.MapIncrementInt("plugins", "total")
+			appstats.IncrementInt("plugins.total")
+			// appstats.MapIncrementInt("plugins", "total")
 			plug.command = cmdName
 			p.logger.Info().
 				Str("id", fileBase).
@@ -262,7 +263,8 @@ func (p *Plugins) scanPluginDirectory(b *builtins.Builtins) error {
 					plug = p.active[pluginName]
 				}
 
-				appstats.MapIncrementInt("plugins", "total")
+				appstats.IncrementInt("plugins.total")
+				// appstats.MapIncrementInt("plugins", "total")
 				plug.command = cmdName
 				p.logger.Info().
 					Str("id", pluginName).

--- a/internal/reverse/command.go
+++ b/internal/reverse/command.go
@@ -142,6 +142,8 @@ func (c *Connection) processCommand(cmd command) command {
 	}
 
 	if cmd.name == c.cmdReset {
+		cmd.err = errors.New("received RESET command from broker")
+		cmd.ignore = false
 		cmd.reset = true
 		return cmd
 	}

--- a/internal/reverse/command_test.go
+++ b/internal/reverse/command_test.go
@@ -107,7 +107,7 @@ func TestProcessCommand(t *testing.T) {
 	}{
 		{"valid connect", command{name: "CONNECT", request: []byte("GET /\r\n\r\n")}, false, nil},
 		{"invalid connect - zero len request", command{name: "CONNECT", request: []byte("")}, true, errors.New("invalid connect command, 0 length request")},
-		{"valid reset", command{name: "RESET", reset: true}, false, nil},
+		{"valid reset", command{name: "RESET", reset: true}, true, errors.New("received RESET command from broker")},
 		{"cmd err - ignored (SHUTDOWN)", command{name: "SHUTDOWN", ignore: true}, true, errors.New("unused/empty command (SHUTDOWN)")},
 		{"cmd err - ignored (empty)", command{name: "", ignore: true}, true, errors.New("unused/empty command ()")},
 		{"cmd err", command{err: errors.New("command error")}, true, errors.New("command error")},

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -15,10 +15,10 @@ import (
 func (s *Server) router(w http.ResponseWriter, r *http.Request) {
 	appstats.IncrementInt("requests_total")
 
-	s.logger.Info().
+	s.logger.Debug().
 		Str("method", r.Method).
 		Str("url", r.URL.String()).
-		Msg("Request")
+		Msg("request")
 
 	switch r.Method {
 	case "GET":


### PR DESCRIPTION
* fix: add error to reset command result so it is honored
* fix: remove deadlock in setReverseConfig
* upd: revert max reverse conn retries back to infinite (-1)
* upd: switch server request logging to debug level
* fix: handle enable new metrics when there's an error with the state directory. Disable new metric enabling and turn off check management, but allow check to be created.
* upd: export plugin/builtin stat times as strings for json
