### PR TITLE
Reduce the log level of the "already running" status message from info to debug

### DIFF
--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -270,7 +270,7 @@ func (p *plugin) exec() error {
 
 	if p.running {
 		msg := "already running"
-		plog.Info().Msg(msg)
+		plog.Debug().Msg(msg)
 		p.Unlock()
 		return errors.New(msg)
 	}


### PR DESCRIPTION
This helps keep all io_latency log messages behind the same log level:

```
{"level":"debug","pkg":"plugins","plugin":"io_latency","time":"2018-08-19T01:38:10.735137914Z","message":"Running"}
{"level":"info","pkg":"plugins","plugin":"io_latency","time":"2018-08-19T01:38:10.73517506Z","message":"already running"}
```

This change alone reduces our log volume by ~50%.

```
$ nomad logs -stderr 6de93d0e | grep -v '"level":"debug"' | wc -l
3424
$ nomad logs -stderr 6de93d0e | grep -v '"level":"debug"' | grep -v 'already running' | wc -l
1722
```

Ideally our `info` log level allows for only the following output during normal operation:

```
{"level":"info","pkg":"server","time":"2018-08-19T01:41:10.745139234Z","message":"sent 595 metrics"}
{"level":"info","pkg":"server","time":"2018-08-19T01:42:12.388977424Z","message":"sent 595 metrics"}
{"level":"info","pkg":"server","time":"2018-08-19T01:43:10.74581418Z","message":"sent 591 metrics"}
{"level":"info","pkg":"server","time":"2018-08-19T01:44:10.745149534Z","message":"sent 595 metrics"}
{"level":"info","pkg":"server","time":"2018-08-19T01:45:10.745689643Z","message":"sent 595 metrics"}
```