### PR TITLE
v0.16.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,7 @@ release:
         owner: circonus-labs
         name: circonus-agent
 
-    draft: true
+    draft: false
 
 snapshot:
     name_template: SNAPSHOT-{{.Commit}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v0.16.2
+
+* upd: goreleaser, turn off draft
+* upd: refactor rhel sysv restart
+* fix: ubuntu start-stop-daemon add timeout to stops to allow conns to cleanup
+* fix: ubuntu init.d/circonus-agent 0755
+* upd: fix ubuntu service config installs
+* upd: centos build vm to 7.4
+* upd: disable logging for sysv init scripts
+* upd: use `@@SBIN@@` in service configs and builder script
+* upd: service script installs to account for alternate install_prefix
+* upd: show file copies
+* upd: builder (el6, el7, ubuntu14, ubuntu16, tgz)
+* doc: service directory configs
+* add: sysv init configs
+
 # v0.16.1
 
 * wip: package builder (incomplete)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure('2') do |config|
     # el7 builder
     #
     config.vm.define 'c7', autostart: false do |c7|
-        c7.vm.box = 'maier/centos-7.3.1611-x86_64'
+        c7.vm.box = 'maier/centos-7.4.1708-x86_64'
         c7.vm.provider 'virtualbox' do |vb|
             vb.name = 'c7_circonus-agent'
             vb.cpus = 2

--- a/package/build.sh
+++ b/package/build.sh
@@ -405,6 +405,7 @@ install_service() {
         ubuntu\.14*)
             $MKDIR -p $dir_install/etc/init.d
             $SED -e "${sed_script}" ../service/circonus-agent.init-ubuntu > $dir_install/etc/init.d/circonus-agent
+            chmod 755 $dir_install/etc/init.d/circonus-agent
             ;;
         *)
             echo "no pre-built service configuration available for $os_name"

--- a/package/build.sh
+++ b/package/build.sh
@@ -386,19 +386,21 @@ install_service() {
     echo "Installing circonus-agent service configuration"
     echo
 
+    local sed_script="s#@@SBIN@@#${dir_install_prefix}/agent/sbin#"
+
     # NOTE: just copy the file, let packaging handle perms
     case $os_name in
         el7|ubuntu16)
             $MKDIR -p $dir_install/lib/systemd/system
-            $CP $CP_ARGS ../service/circonus-agent.service $dir_install/lib/systemd/system
+            $SED -e "${sed_script}" ../service/circonus-agent.service > $dir_install/lib/systemd/system
             ;;
         el6)
             $MKDIR -p $dir_install/etc/init.d
-            $CP $CP_ARGS ../service/circonus-agent.init-rhel $dir_install/etc/init.d/circonus-agent
+            $SED -e "${sed_script}" ../service/circonus-agent.init-rhel > $dir_install/etc/init.d/circonus-agent
             ;;
         ubuntu14)
             $MKDIR -p $dir_install/etc/init.d
-            $CP $CP_ARGS ../service/circonus-agent.init-ubuntu $dir_install/etc/init.d/circonus-agent
+            $SED -e "${sed_script}" ../service/circonus-agent.init-ubuntu > $dir_install/etc/init.d/circonus-agent
             ;;
         *)
             echo "no pre-built service configuration available for $os_name"

--- a/package/build.sh
+++ b/package/build.sh
@@ -390,15 +390,19 @@ install_service() {
 
     # NOTE: just copy the file, let packaging handle perms
     case $os_name in
-        el7|ubuntu16)
+        el7)
             $MKDIR -p $dir_install/lib/systemd/system
-            $SED -e "${sed_script}" ../service/circonus-agent.service > $dir_install/lib/systemd/system
+            $SED -e "${sed_script}" ../service/circonus-agent.service > $dir_install/lib/systemd/system/circonus-agent.service
             ;;
         el6)
             $MKDIR -p $dir_install/etc/init.d
             $SED -e "${sed_script}" ../service/circonus-agent.init-rhel > $dir_install/etc/init.d/circonus-agent
             ;;
-        ubuntu14)
+        ubuntu\.16*)
+            $MKDIR -p $dir_install/lib/systemd/system
+            $SED -e "${sed_script}" ../service/circonus-agent.service > $dir_install/lib/systemd/system/circonus-agent.service
+            ;;
+        ubuntu\.14*)
             $MKDIR -p $dir_install/etc/init.d
             $SED -e "${sed_script}" ../service/circonus-agent.init-ubuntu > $dir_install/etc/init.d/circonus-agent
             ;;

--- a/package/build.sh
+++ b/package/build.sh
@@ -83,6 +83,7 @@ dir_logwatch_build="${dir_build}/${logwatch_name}"
 # commands used during build/install
 #
 : ${CP:="cp"}
+: ${CP_ARGS:="-v"}
 : ${CURL:="curl"}
 : ${GIT:="git"}
 : ${GO:="go"} # for protocol_observer (requires cgo)
@@ -307,9 +308,10 @@ install_protocol_observer() {
     pushd protocol_observer >/dev/null
     echo "-building protocol_observer (${dest_bin})"
     $GO build -o $dest_bin
+    echo "-installed ${dest_bin}"
     [[ -f README.md ]] && {
         echo "-installing protocol_observer doc (${dest_doc})"
-        $CP README.md $dest_doc
+        $CP $CP_ARGS README.md $dest_doc
     }
     popd >/dev/null
     # the following line is for go 1.11 modules (outside of GOPATH)
@@ -388,15 +390,15 @@ install_service() {
     case $os_name in
         el7|ubuntu16)
             $MKDIR -p $dir_install/lib/systemd/system
-            $CP ../service/circonus-agent.service $dir_install/lib/systemd/system
+            $CP $CP_ARGS ../service/circonus-agent.service $dir_install/lib/systemd/system
             ;;
         el6)
             $MKDIR -p $dir_install/etc/init.d
-            $CP ../service/circonus-agent.init-rhel $dir_install/etc/init.d/circonus-agent
+            $CP $CP_ARGS ../service/circonus-agent.init-rhel $dir_install/etc/init.d/circonus-agent
             ;;
         ubuntu14)
             $MKDIR -p $dir_install/etc/init.d
-            $CP ../service/circonus-agent.init-ubuntu $dir_install/etc/init.d/circonus-agent
+            $CP $CP_ARGS ../service/circonus-agent.init-ubuntu $dir_install/etc/init.d/circonus-agent
             ;;
         *)
             echo "no pre-built service configuration available for $os_name"
@@ -425,7 +427,7 @@ make_package() {
             echo "making RPM for $os_name"
             $SED -e "s#@@RPMVER@@#${stripped_ver}#" rhel/circonus-agent.spec.in > rhel/circonus-agent.spec
             $RPMBUILD -bb rhel/circonus-agent.spec
-            $CP ~/rpmbuild/RPMS/*/circonus-agent-$stripped_ver-1.*.$os_arch.rpm $dir_publish
+            $CP $CP_ARGS ~/rpmbuild/RPMS/*/circonus-agent-$stripped_ver-1.*.$os_arch.rpm $dir_publish
             $RM rhel/circonus-agent.spec
             ;;
         ubuntu*)
@@ -454,7 +456,7 @@ make_package() {
                 --deb-group root \
                 --after-install ${PWD}/ubuntu/postinstall.sh \
                 --after-remove ${PWD}/ubuntu/postremove.sh
-            $CP $deb_file $dir_publish
+            $CP $CP_ARGS $deb_file $dir_publish
             $RM $deb_file
             ;;
         *)
@@ -462,7 +464,7 @@ make_package() {
             echo "making tgz for $os_name"
             local pkg="${dir_build}/circonus-agent-${stripped_ver}-1.${os_name}_${os_arch}.tgz"
             $TAR czf $pkg .
-            $CP $pkg $dir_publish
+            $CP $CP_ARGS $pkg $dir_publish
             $RM $pkg
             popd >/dev/null
             ;;

--- a/service/circonus-agent.init-rhel
+++ b/service/circonus-agent.init-rhel
@@ -28,7 +28,7 @@ agent_cmd="@@SBIN@@/${agent}"
 pid_file="/var/run/${agent}.pid"
 
 start_agent() {
-    $agent_cmd 2>&1 >/dev/null &
+    $agent_cmd --log-level=disabled &
     pid=$!
     RETVAL=$?
     if [[ $RETVAL -eq 0 ]]; then

--- a/service/circonus-agent.init-rhel
+++ b/service/circonus-agent.init-rhel
@@ -82,11 +82,7 @@ case "$1" in
         status -p $pid_file $agent
         RETVAL=$?
         ;;
-    reload|force-reload)
-        stop
-        start
-        ;;
-    restart)
+    reload|force-reload|restart)
         stop
         start
         ;;

--- a/service/circonus-agent.init-ubuntu
+++ b/service/circonus-agent.init-ubuntu
@@ -25,7 +25,7 @@ test -x $agent_cmd || exit 0
 . /lib/lsb/init-functions
 
 start_agent() {
-    if start-stop-daemon --start --quiet --pidfile $pid_file --exec $agent_cmd -- --log-level=disabled
+    if start-stop-daemon --start --background --quiet --pidfile $pid_file --make-pidfile --exec $agent_cmd -- --log-level=disabled
     then
         rc=0
         sleep 1
@@ -52,12 +52,14 @@ restart_agent() {
     set +e
 	log_daemon_msg "Restarting Circonus agent daemon" $agent
 	if [ -s $pid_file ] && kill -0 $(cat $pid_file) >/dev/null 2>&1; then
-	    start-stop-daemon --stop --quiet --oknodo --pidfile $pid_file || true
-	    sleep 1
+        # NOTE: retry is used because if the agent is in reverse mode the daemon
+        #       can take a bit to timeout waiting for commands from the broker
+	    start-stop-daemon --stop --quiet --oknodo --retry 15 --pidfile $pid_file
 	else
 	    log_warning_msg "Circonus agent daemon not running, attempting to start."
 		rm -f $pid_file
 	fi
+    set -e
     start_agent
 }
 

--- a/service/circonus-agent.init-ubuntu
+++ b/service/circonus-agent.init-ubuntu
@@ -25,7 +25,7 @@ test -x $agent_cmd || exit 0
 . /lib/lsb/init-functions
 
 start_agent() {
-    if start-stop-daemon --start --quiet --pidfile $pid_file --exec $agent_cmd
+    if start-stop-daemon --start --quiet --pidfile $pid_file --exec $agent_cmd -- --log-level=disabled
     then
         rc=0
         sleep 1

--- a/service/circonus-agent.service
+++ b/service/circonus-agent.service
@@ -4,7 +4,7 @@ Documentation=http://github.com/circonus-labs/circonus-agent
 After=network.target
 
 [Service]
-ExecStart=/opt/circonus/agent/sbin/circonus-agentd
+ExecStart=@@SBIN@@/circonus-agentd
 Restart=always
 User=nobody
 


### PR DESCRIPTION
* upd: goreleaser, turn off draft
* upd: refactor rhel sysv restart
* fix: ubuntu start-stop-daemon add timeout to stops to allow conns to cleanup
* fix: ubuntu init.d/circonus-agent 0755
* upd: fix ubuntu service config installs
* upd: centos build vm to 7.4
* upd: disable logging for sysv init scripts
* upd: use `@@SBIN@@` in service configs and builder script
* upd: service script installs to account for alternate install_prefix
* upd: show file copies
* upd: builder (el6, el7, ubuntu14, ubuntu16, tgz)
* doc: service directory configs
* add: sysv init configs
