### PR TITLE
v0.18.0-alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # v0.18.0
 
+* **alpha2**
+  * add: `--plugin-list` (`plugin_list` config file) option
+    * `plugin-list` and `plugin-dir` are mutually exclusive, use one **or** the other
+    * `plugin-list` is an _explcit_ list of commands to run as plugins
+    * If neither is supplied use default `plugin-dir` (`/opt/circonus/agent/plugins`)
+    * If `plugin-list` is supplied **only** those plugins will be run; any plugins in the `plugin-dir` will be ignored
+    * If both `plugin-dir` and `plugin-list` are supplied, agent will exit with a mis-configuration error
 * **alpha1**
   * doc: add markdown linter config
   * upd: refactor metrics flush/aggregate, channel vs mutex lock, improve debug messages

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,10 +150,22 @@ func init() {
 			description = "Plugin directory"
 		)
 
-		RootCmd.Flags().StringP(longOpt, shortOpt, defaults.PluginPath, desc(description, envVar))
+		RootCmd.Flags().StringP(longOpt, shortOpt, "", desc(description, envVar))
 		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
 		viper.BindEnv(key, envVar)
-		viper.SetDefault(key, defaults.PluginPath)
+	}
+
+	{
+		const (
+			key         = config.KeyPluginList
+			longOpt     = "plugin-list"
+			envVar      = release.ENVPREFIX + "_PLUGIN_LIST"
+			description = "List of explicit plugin commands to run"
+		)
+
+		RootCmd.Flags().StringSlice(longOpt, []string{}, desc(description, envVar))
+		viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt))
+		viper.BindEnv(key, envVar)
 	}
 
 	{

--- a/internal/agent/main.go
+++ b/internal/agent/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/circonus-labs/circonus-agent/internal/builtins"
 	"github.com/circonus-labs/circonus-agent/internal/check"
 	"github.com/circonus-labs/circonus-agent/internal/config"
+	"github.com/circonus-labs/circonus-agent/internal/config/defaults"
 	"github.com/circonus-labs/circonus-agent/internal/plugins"
 	"github.com/circonus-labs/circonus-agent/internal/release"
 	"github.com/circonus-labs/circonus-agent/internal/reverse"

--- a/internal/agent/main.go
+++ b/internal/agent/main.go
@@ -64,7 +64,7 @@ func New() (*Agent, error) {
 		return nil, err
 	}
 
-	a.plugins, err = plugins.New(a.groupCtx)
+	a.plugins, err = plugins.New(a.groupCtx, defaults.PluginPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -10,7 +10,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/circonus-labs/circonus-agent/internal/config/defaults"
 	toml "github.com/pelletier/go-toml"
@@ -105,14 +104,11 @@ type Config struct {
 	ListenSocket     []string `mapstructure:"listen_socket" json:"listen_socket" yaml:"listen_socket" toml:"listen_socket"`
 	Log              Log      `json:"log" yaml:"log" toml:"log"`
 	PluginDir        string   `mapstructure:"plugin_dir" json:"plugin_dir" yaml:"plugin_dir" toml:"plugin_dir"`
+	PluginList       []string `mapstructure:"plugin_list" json:"plugin_list" yaml:"plugin_list" toml:"plugin_list"`
 	PluginTTLUnits   string   `mapstructure:"plugin_ttl_units" json:"plugin_ttl_units" yaml:"plugin_ttl_units" toml:"plugin_ttl_units"`
 	Reverse          Reverse  `json:"reverse" yaml:"reverse" toml:"reverse"`
 	SSL              SSL      `json:"ssl" yaml:"ssl" toml:"ssl"`
 	StatsD           StatsD   `json:"statsd" yaml:"statsd" toml:"statsd"`
-}
-
-type cosiCheckConfig struct {
-	CID string `json:"_cid"`
 }
 
 //
@@ -156,6 +152,8 @@ const (
 
 	// KeyPluginDir plugin directory
 	KeyPluginDir = "plugin_dir"
+	// KeyPluginList is a list of explicit commands to run as plugins
+	KeyPluginList = "plugin_list"
 
 	// KeyPluginTTLUnits plugin run ttl units
 	KeyPluginTTLUnits = "plugin_ttl_units"
@@ -269,8 +267,6 @@ const (
 )
 
 var (
-	cosiCfgFile = filepath.Join(defaults.BasePath, "..", cosiName, "etc", "cosi.json")
-
 	// MetricNameSeparator defines character used to delimit metric name parts
 	MetricNameSeparator = defaults.MetricNameSeparator // var, TBD whether it will become configurable
 )

--- a/internal/plugins/scan_test.go
+++ b/internal/plugins/scan_test.go
@@ -7,6 +7,7 @@ package plugins
 
 import (
 	"context"
+	"path"
 	"testing"
 
 	"github.com/circonus-labs/circonus-agent/internal/builtins"
@@ -30,11 +31,12 @@ func TestScan(t *testing.T) {
 
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 
-	t.Log("Valid plugin directory")
+	t.Log("valid - plugin directory")
 	{
+		viper.Reset()
 		viper.Set(config.KeyPluginDir, "testdata/")
 
-		p, nerr := New(context.Background())
+		p, nerr := New(context.Background(), "")
 		if nerr != nil {
 			t.Fatalf("expected NO error, got (%s)", nerr)
 		}
@@ -48,6 +50,25 @@ func TestScan(t *testing.T) {
 		}
 	}
 
+	t.Log("valid - plugin list")
+	{
+		viper.Reset()
+		viper.Set(config.KeyPluginDir, "")
+		viper.Set(config.KeyPluginList, []string{path.Join("testdata", "test.sh")})
+
+		p, nerr := New(context.Background(), "")
+		if nerr != nil {
+			t.Fatalf("expected NO error, got (%s)", nerr)
+		}
+		b, berr := builtins.New()
+		if berr != nil {
+			t.Fatalf("expected NO error, got (%s)", berr)
+		}
+		err := p.Scan(b)
+		if err != nil {
+			t.Fatalf("expected NO error, got (%s)", err)
+		}
+	}
 }
 
 func TestScanPluginDirectory(t *testing.T) {
@@ -55,7 +76,7 @@ func TestScanPluginDirectory(t *testing.T) {
 
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 
-	p, nerr := New(context.Background())
+	p, nerr := New(context.Background(), "")
 	if nerr != nil {
 		t.Fatalf("new err %s", nerr)
 	}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -57,7 +57,7 @@ func TestRun(t *testing.T) {
 	if berr != nil {
 		t.Fatalf("expected no error, got (%s)", berr)
 	}
-	p, perr := plugins.New(context.Background())
+	p, perr := plugins.New(context.Background(), "")
 	if perr != nil {
 		t.Fatalf("expected NO error, got (%s)", perr)
 	}
@@ -105,7 +105,7 @@ func TestInventory(t *testing.T) {
 	viper.Reset()
 	viper.Set(config.KeyListen, ":2609")
 	viper.Set(config.KeyPluginDir, testDir)
-	p, perr := plugins.New(context.Background())
+	p, perr := plugins.New(context.Background(), "")
 	if perr != nil {
 		t.Fatalf("expected NO error, got (%s)", perr)
 	}

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -68,7 +68,7 @@ func TestRouter(t *testing.T) {
 		if berr != nil {
 			t.Fatalf("expected no error, got (%s)", berr)
 		}
-		p, perr := plugins.New(context.Background())
+		p, perr := plugins.New(context.Background(), "")
 		if perr != nil {
 			t.Fatalf("expected NO error, got (%s)", perr)
 		}
@@ -116,7 +116,7 @@ func TestRouter(t *testing.T) {
 		if berr != nil {
 			t.Fatalf("expected no error, got (%s)", berr)
 		}
-		p, perr := plugins.New(context.Background())
+		p, perr := plugins.New(context.Background(), "")
 		if perr != nil {
 			t.Fatalf("expected NO error, got (%s)", perr)
 		}
@@ -172,7 +172,7 @@ func TestRouter(t *testing.T) {
 		if berr != nil {
 			t.Fatalf("expected no error, got (%s)", berr)
 		}
-		p, perr := plugins.New(context.Background())
+		p, perr := plugins.New(context.Background(), "")
 		if perr != nil {
 			t.Fatalf("expected NO error, got (%s)", perr)
 		}


### PR DESCRIPTION
  * add: `--plugin-list` (`plugin_list` config file) option
    * `plugin-list` and `plugin-dir` are mutually exclusive, use one **or** the other
    * `plugin-list` is an _explcit_ list of commands to run as plugins
    * If neither is supplied use default `plugin-dir` (`/opt/circonus/agent/plugins`)
    * If `plugin-list` is supplied **only** those plugins will be run; any plugins in the `plugin-dir` will be ignored
    * If both `plugin-dir` and `plugin-list` are supplied, agent will exit with a mis-configuration error
