### PR TITLE
[CIRC-4108] v1.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.0-beta.1
+
+* fix: output all parsed plugin metrics with streamtags, include any tags from `_tags` attribute of emitted json
+* fix: output tags `io_latency` in `_tags` attribute rather than in metric name (so they can be combined with agent tags to create stream tagged metric name)
+* add: statsd tcp listner (optional, off by default)
+
 # v1.0.0-alpha.5
 
 * add: clustered broker support (initial)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -796,6 +796,42 @@ func init() {
 		viper.SetDefault(key, defaults.StatsdGroupSets)
 	}
 
+	{
+		const (
+			key         = config.KeyStatsdEnableTCP
+			longOpt     = "statsd-enable-tcp"
+			envVar      = release.ENVPREFIX + "_STATSD_ENABLE_TCP"
+			description = "Enable StatsD TCP listener"
+		)
+
+		RootCmd.Flags().Bool(longOpt, defaults.StatsdEnableTCP, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaults.StatsdEnableTCP)
+	}
+
+	{
+		const (
+			key         = config.KeyStatsdMaxTCPConns
+			longOpt     = "statsd-max-tcp-connections"
+			envVar      = release.ENVPREFIX + "_STATSD_MAX_TCP_CONNS"
+			description = "StatsD maximum TCP connections"
+		)
+
+		RootCmd.Flags().Uint(longOpt, defaults.StatsdMaxTCPConns, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaults.StatsdMaxTCPConns)
+	}
+
 	// Miscellenous
 
 	{

--- a/internal/config/defaults/main.go
+++ b/internal/config/defaults/main.go
@@ -74,6 +74,12 @@ const (
 	// StatsdGroupSets defines how group counter metrics will be handled (average or sum)
 	StatsdGroupSets = "sum"
 
+	// StatsdEnableTCP defines if the statsd tcp listener is enabled
+	StatsdEnableTCP = false
+
+	// StatsdMaxTCPConns defines the max statsd tcp client connections
+	StatsdMaxTCPConns = uint(250)
+
 	// MetricNameSeparator defines character used to delimit metric name parts
 	MetricNameSeparator = "`"
 

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -216,6 +216,12 @@ const (
 	// KeyStatsdPort port for statsd listener (note, address will always be 'localhost')
 	KeyStatsdPort = "statsd.port"
 
+	// KeyStatsdEnableTCP enables statsd tcp listener
+	KeyStatsdEnableTCP = "statsd.enable_tcp"
+
+	// KeyStatsdMaxTCPConns set max statsd tcp connections
+	KeyStatsdMaxTCPConns = "statsd.max_tcp_connections"
+
 	// KeyCollectors defines the builtin collectors to enable
 	KeyCollectors = "collectors"
 

--- a/internal/statsd/metrics_test.go
+++ b/internal/statsd/metrics_test.go
@@ -44,7 +44,6 @@ func TestProcessPacket(t *testing.T) {
 		s.processPacket([]byte("test"))
 	}
 
-	s.listener.Close()
 	viper.Reset()
 }
 
@@ -85,7 +84,6 @@ func TestGetMetricDest(t *testing.T) {
 			}
 		}
 
-		s.listener.Close()
 		viper.Reset()
 	}
 
@@ -124,7 +122,6 @@ func TestGetMetricDest(t *testing.T) {
 			}
 		}
 
-		s.listener.Close()
 		viper.Reset()
 	}
 
@@ -162,7 +159,6 @@ func TestGetMetricDest(t *testing.T) {
 			}
 		}
 
-		s.listener.Close()
 		viper.Reset()
 	}
 
@@ -200,7 +196,6 @@ func TestGetMetricDest(t *testing.T) {
 			}
 		}
 
-		s.listener.Close()
 		viper.Reset()
 	}
 }
@@ -290,6 +285,4 @@ func TestParseMetric(t *testing.T) {
 			}
 		}
 	}
-
-	s.listener.Close()
 }

--- a/internal/statsd/statsd_test.go
+++ b/internal/statsd/statsd_test.go
@@ -97,7 +97,7 @@ func TestStart(t *testing.T) {
 		viper.Reset()
 	}
 
-	t.Log("Enabled w/Stop")
+	t.Log("Enabled w/context cancel")
 	{
 		viper.Set(config.KeyStatsdDisabled, false)
 		viper.Set(config.KeyStatsdPort, "65125")
@@ -110,36 +110,11 @@ func TestStart(t *testing.T) {
 		if s == nil {
 			t.Fatal("expected not nil")
 		}
-		time.AfterFunc(1*time.Second, func() {
+		time.AfterFunc(2*time.Second, func() {
 			cancel()
 		})
 
 		if err := s.Start(); err != nil {
-			t.Fatalf("unexpected error (%s)", err)
-		}
-		viper.Reset()
-	}
-
-	t.Log("Enabled w/direct server close")
-	{
-		viper.Set(config.KeyStatsdDisabled, false)
-		viper.Set(config.KeyStatsdPort, "65125")
-		viper.Set(config.KeyStatsdHostCategory, defaults.StatsdHostCategory)
-		s, err := New(context.Background())
-		if err != nil {
-			t.Fatalf("expected NO error, got (%s)", err)
-		}
-		if s == nil {
-			t.Fatal("expected not nil")
-		}
-		time.AfterFunc(1*time.Second, func() {
-			s.udpListener.Close()
-		})
-		err = s.Start()
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		if err.Error() != "reader: read udp 127.0.0.1:65125: use of closed network connection" {
 			t.Fatalf("unexpected error (%s)", err)
 		}
 		viper.Reset()

--- a/plugins/linux/io/io_latency/io_latency.go
+++ b/plugins/linux/io/io_latency/io_latency.go
@@ -56,7 +56,8 @@ func dumpHistAndClear() {
 				val := make(map[string]interface{})
 				val["_type"] = "h"
 				val["_value"] = ss
-				tmp[typ+"|ST[device:"+dev+",units:seconds]"] = val
+				val["_tags"] = []string{"device:"+dev,"units:seconds"}
+				tmp[typ] = val
 			}
 		}
 	}


### PR DESCRIPTION
* fix: output all parsed plugin metrics with streamtags, include any tags from `_tags` attribute of emitted json
* fix: output tags `io_latency` in `_tags` attribute rather than in metric name (so they can be combined with agent tags to create stream tagged metric name)
* add: statsd tcp listner (optional, off by default)
