### PR TITLE
v1.0.0-beta.9

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,7 +94,7 @@ archives:
         - README.md
         - CHANGELOG.md
         - etc/README.md
-        - service/circonus-agent.service
+        - service/*
         - state/README.md
         - plugins/**/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.0.0-beta.9
 
+* add: cluster mode statsd gauges as histogram capability (so each node is represented with _one_ sample)
+* add: cluster mode statsd counters and sets as histograms with `statsd_type:count` tag
+* add: cluster mode enable/disable builtins
+* add: cluster mode configuration options
 * add: zpool plugin
 * add: include all service configurations in releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.0.0-beta.9
+
+* add: zpool plugin
+* add: include all service configurations in releases
+
+# v1.0.0-beta.8
+
+* add: EXPOSE to Dockerfile(s) for default listening ports
+
 # v1.0.0-beta.7
 
 * add: docker images

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1058,6 +1058,64 @@ func init() {
 		viper.SetDefault(key, defaults.LogPretty)
 	}
 
+	//
+	// Clustering options
+	//
+	{
+		const (
+			key          = config.KeyClusterEnabled
+			longOpt      = "cluster-enable"
+			envVar       = release.ENVPREFIX + "_CLUSTER_ENABLE"
+			description  = "Enable cluster awareness mode"
+			defaultValue = defaults.ClusterEnabled
+		)
+
+		RootCmd.Flags().Bool(longOpt, defaultValue, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+	{
+		const (
+			key          = config.KeyClusterEnableBuiltins
+			longOpt      = "cluster-enable-builtins"
+			envVar       = release.ENVPREFIX + "_CLUSTER_ENABLE_BUILTINS"
+			description  = "Enable builtins in cluster awareness mode"
+			defaultValue = defaults.ClusterEnableBuiltins
+		)
+
+		RootCmd.Flags().Bool(longOpt, defaultValue, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+	{
+		const (
+			key          = config.KeyClusterStatsdHistogramGauges
+			longOpt      = "cluster-statsd-histogram-gauges"
+			envVar       = release.ENVPREFIX + "_CLUSTER_STATSD_HISTOGRAM_GAUGES"
+			description  = "Represent StatsD gauges as histograms in cluster awareness mode"
+			defaultValue = defaults.ClusterStatsdHistogramGauges
+		)
+
+		RootCmd.Flags().Bool(longOpt, defaultValue, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+
 	// RootCmd.Flags().Bool("watch", defaults.Watch, "Watch plugins, reload on change")
 	// viper.SetDefault("watch", defaults.Watch)
 	// viper.BindPFlag("watch", RootCmd.Flags().Lookup("watch"))

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -1,3 +1,6 @@
 FROM arm64v8/alpine:latest
 COPY circonus-agentd /
+# NOTE: these are the default ports, use -p to map alternatives configured
+EXPOSE 2609/tcp
+EXPOSE 8125/udp
 ENTRYPOINT ["/circonus-agentd"]

--- a/docker/x86_64/Dockerfile
+++ b/docker/x86_64/Dockerfile
@@ -1,3 +1,6 @@
 FROM gcr.io/distroless/static
 COPY circonus-agentd /
+# NOTE: these are the default ports, use -p to map alternatives configured
+EXPOSE 2609/tcp
+EXPOSE 8125/udp
 ENTRYPOINT ["/circonus-agentd"]

--- a/internal/builtins/builtins.go
+++ b/internal/builtins/builtins.go
@@ -11,11 +11,13 @@ import (
 	"time"
 
 	"github.com/circonus-labs/circonus-agent/internal/builtins/collector"
+	"github.com/circonus-labs/circonus-agent/internal/config"
 	cgm "github.com/circonus-labs/circonus-gometrics/v3"
 	appstats "github.com/maier/go-appstats"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 // Builtins defines the internal metric collector manager
@@ -34,6 +36,11 @@ func New() (*Builtins, error) {
 	}
 
 	b.logger.Info().Msg("configuring builtins")
+
+	if viper.GetBool(config.KeyClusterEnabled) && !viper.GetBool(config.KeyClusterEnableBuiltins) {
+		b.logger.Info().Msg("cluster mode - builtins disabled")
+		return &b, nil
+	}
 
 	err := b.configure()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -293,6 +293,16 @@ const (
 	// KeyCheckMetricStreamtags specifies whether to use stream tags (if stream tags are enabled, check tags are added to all metrics by default)
 	KeyCheckMetricStreamtags = "check.metric_streamtags"
 
+	// Cluster mode
+	KeyCluster = "cluster"
+	// Cluster mode enabled
+	KeyClusterEnabled = "cluster.enabled"
+	// Cluster mode enable builtins (host filesystems must be mounted in container and corresponding
+	// `HOST_*`` environment variables must be set)
+	KeyClusterEnableBuiltins = "cluster.enable_builtins"
+	// Cluster mode represent statsd gauges as histogram samples, so that _one_ sample will be collected for each node
+	KeyClusterStatsdHistogramGauges = "cluster.statsd_histogram_gauges"
+
 	cosiName = "cosi"
 )
 

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -114,6 +114,14 @@ const (
 
 	// CheckTags to use if creating a check (comma separated list)
 	CheckTags = ""
+
+	// Cluster mode enabled
+	ClusterEnabled = false
+	// Cluster mode enable builtins (host filesystems must be mounted in container and corresponding
+	// `HOST_*`` environment variables must be set)
+	ClusterEnableBuiltins = false
+	// Cluster mode represent statsd gauges as histogram samples, so that _one_ sample will be collected for each node
+	ClusterStatsdHistogramGauges = false
 )
 
 var (

--- a/internal/statsd/metrics.go
+++ b/internal/statsd/metrics.go
@@ -152,7 +152,8 @@ func (s *Server) parseMetric(metric string) error {
 		if sampleRate > 0 {
 			v = uint64(float64(v) * (1 / sampleRate))
 		}
-		dest.IncrementByValueWithTags(metricName, metricTags, v)
+		dest.RecordCountForValueWithTags(metricName, append(metricTags, cgm.Tag{Category: "statsd_type", Value: "count"}), 0, int64(v))
+		//dest.IncrementByValueWithTags(metricName, metricTags, v)
 	case "g": // gauge
 		switch {
 		case strings.Contains(metricValue, "."):
@@ -188,8 +189,11 @@ func (s *Server) parseMetric(metric string) error {
 	case "s": // set
 		// in the case of sets, the value is the unique "thing" to be tracked
 		// counters are used to track individual "things"
-		metricTags = append(metricTags, cgm.Tag{Category: "set_id", Value: metricValue})
-		dest.IncrementWithTags(metricName, metricTags)
+		dest.RecordCountForValueWithTags(metricName,
+			append(metricTags, cgm.Tags{
+				cgm.Tag{Category: "set_id", Value: metricValue},
+				cgm.Tag{Category: "statsd_type", Value: "count"}}...), 0, 1)
+		//dest.IncrementWithTags(metricName, append(metricTags, cgm.Tags{cgm.Tag{Category: "set_id", Value: metricValue}))
 	case "t": // text (circonus)
 		dest.SetTextWithTags(metricName, metricTags, metricValue)
 	default:

--- a/internal/statsd/metrics.go
+++ b/internal/statsd/metrics.go
@@ -10,10 +10,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/circonus-labs/circonus-agent/internal/config"
 	"github.com/circonus-labs/circonus-agent/internal/tags"
 	cgm "github.com/circonus-labs/circonus-gometrics/v3"
 	"github.com/maier/go-appstats"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 // processPacket parses a packet for metrics
@@ -152,28 +154,42 @@ func (s *Server) parseMetric(metric string) error {
 		if sampleRate > 0 {
 			v = uint64(float64(v) * (1 / sampleRate))
 		}
-		dest.RecordCountForValueWithTags(metricName, append(metricTags, cgm.Tag{Category: "statsd_type", Value: "count"}), 0, int64(v))
-		//dest.IncrementByValueWithTags(metricName, metricTags, v)
+		if viper.GetBool(config.KeyClusterEnabled) {
+			metricTags = append(metricTags, cgm.Tag{Category: "statsd_type", Value: "count"})
+			dest.RecordCountForValueWithTags(metricName, metricTags, 0, int64(v))
+		} else {
+			dest.IncrementByValueWithTags(metricName, metricTags, v)
+		}
 	case "g": // gauge
+		var val interface{}
 		switch {
 		case strings.Contains(metricValue, "."):
 			v, err := strconv.ParseFloat(metricValue, 64)
 			if err != nil {
 				return errors.Wrap(err, "invalid gauge value")
 			}
-			dest.GaugeWithTags(metricName, metricTags, v)
+			val = v
+			// dest.GaugeWithTags(metricName, metricTags, v)
 		case strings.Contains(metricValue, "-"):
 			v, err := strconv.ParseInt(metricValue, 10, 64)
 			if err != nil {
 				return errors.Wrap(err, "invalid gauge value")
 			}
-			dest.GaugeWithTags(metricName, metricTags, v)
+			val = v
+			// dest.GaugeWithTags(metricName, metricTags, v)
 		default:
 			v, err := strconv.ParseUint(metricValue, 10, 64)
 			if err != nil {
 				return errors.Wrap(err, "invalid gauge value")
 			}
-			dest.GaugeWithTags(metricName, metricTags, v)
+			val = v
+			// dest.GaugeWithTags(metricName, metricTags, v)
+		}
+		if viper.GetBool(config.KeyClusterEnabled) && viper.GetBool(config.KeyClusterStatsdHistogramGauges) {
+			dest.RemoveHistogramWithTags(metricName, metricTags)
+			dest.SetHistogramValueWithTags(metricName, metricTags, val.(float64))
+		} else {
+			dest.GaugeWithTags(metricName, metricTags, val)
 		}
 	case "h": // histogram (circonus)
 		fallthrough
@@ -189,11 +205,13 @@ func (s *Server) parseMetric(metric string) error {
 	case "s": // set
 		// in the case of sets, the value is the unique "thing" to be tracked
 		// counters are used to track individual "things"
-		dest.RecordCountForValueWithTags(metricName,
-			append(metricTags, cgm.Tags{
-				cgm.Tag{Category: "set_id", Value: metricValue},
-				cgm.Tag{Category: "statsd_type", Value: "count"}}...), 0, 1)
-		//dest.IncrementWithTags(metricName, append(metricTags, cgm.Tags{cgm.Tag{Category: "set_id", Value: metricValue}))
+		metricTags = append(metricTags, cgm.Tag{Category: "set_id", Value: metricValue})
+		if viper.GetBool(config.KeyClusterEnabled) {
+			metricTags = append(metricTags, cgm.Tag{Category: "statsd_type", Value: "count"})
+			dest.RecordCountForValueWithTags(metricName, metricTags, 0, 1)
+		} else {
+			dest.IncrementWithTags(metricName, metricTags)
+		}
 	case "t": // text (circonus)
 		dest.SetTextWithTags(metricName, metricTags, metricValue)
 	default:


### PR DESCRIPTION
* add: cluster mode statsd gauges as histogram capability (so each node is represented with _one_ sample)
* add: cluster mode statsd counters and sets as histograms with `statsd_type:count` tag
* add: cluster mode enable/disable builtins
* add: cluster mode configuration options
* add: zpool plugin
* add: include all service configurations in releases