### PR TITLE
v1.0.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,8 @@ builds:
         env:
             - CGO_ENABLED=0
 
-        flags: -tags dev
+        flags: 
+            #- -a
 
         goos:
             - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.1
+
+* add: `--statsd-addr`, `CA_STATSD_ADDR` to explicitly specify an address that statsd should listen to (e.g. `--statsd-addr=0.0.0.0` for docker containers, so the port can be properly exposed).
+* fix: procfs.disk use `HOST_SYS` if provided
+
 # v1.0.0
 
 * add: nvidia gpu metrics builtin for windows platform

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Flags:
       --debug-cgm                         [ENV: CA_DEBUG_CGM] Enable CGM debug messages
       --debug-dump-metrics string         [ENV: CA_DEBUG_DUMP_METRICS] Directory to dump sent metrics
   -h, --help                              help for circonus-agent
+      --host-etc string                   [ENV: HOST_ETC] Host /etc directory
+      --host-proc string                  [ENV: HOST_PROC] Host /proc directory
+      --host-run string                   [ENV: HOST_RUN] Host /run directory
+      --host-sys string                   [ENV: HOST_SYS] Host /sys directory
+      --host-var string                   [ENV: HOST_VAR] Host /var directory
   -l, --listen strings                    [ENV: CA_LISTEN] Listen spec e.g. :2609, [::1], [::1]:2609, 127.0.0.1, 127.0.0.1:2609, foo.bar.baz, foo.bar.baz:2609 (default ":2609")
   -L, --listen-socket strings             [ENV: CA_LISTEN_SOCKET] Unix socket to create
       --log-level string                  [ENV: CA_LOG_LEVEL] Log level [(panic|fatal|error|warn|info|debug|disabled)] (default "info")
@@ -149,6 +154,7 @@ Flags:
       --ssl-key-file string               [ENV: CA_SSL_KEY_FILE] SSL Key file (default "/opt/circonus/agent/etc/circonus-agent.key")
       --ssl-listen string                 [ENV: CA_SSL_LISTEN] SSL listen address and port [IP]:[PORT] - setting enables SSL
       --ssl-verify                        [ENV: CA_SSL_VERIFY] Enable SSL verification (default true)
+      --statsd-addr string                [ENV: CA_STATSD_ADDR] StatsD address to listen on (default "localhost")
       --statsd-group-cid string           [ENV: CA_STATSD_GROUP_CID] StatsD group check bundle ID
       --statsd-group-counters string      [ENV: CA_STATSD_GROUP_COUNTERS] StatsD group metric counter handling (average|sum) (default "sum")
       --statsd-group-gauges string        [ENV: CA_STATSD_GROUP_GAUGES] StatsD group gauge operator (default "average")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -756,7 +756,7 @@ func init() {
 			description = "StatsD address to listen on"
 		)
 
-		RootCmd.Flags().String(longOpt, defaults.StatsdPort, desc(description, envVar))
+		RootCmd.Flags().String(longOpt, defaults.StatsdAddr, desc(description, envVar))
 		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
 			bindFlagError(longOpt, err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -750,10 +750,28 @@ func init() {
 
 	{
 		const (
+			key         = config.KeyStatsdAddr
+			longOpt     = "statsd-addr"
+			envVar      = release.ENVPREFIX + "_STATSD_ADDR"
+			description = "StatsD address to listen on"
+		)
+
+		RootCmd.Flags().String(longOpt, defaults.StatsdPort, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaults.StatsdAddr)
+	}
+
+	{
+		const (
 			key         = config.KeyStatsdPort
 			longOpt     = "statsd-port"
 			envVar      = release.ENVPREFIX + "_STATSD_PORT"
-			description = "StatsD port"
+			description = "StatsD port to listen on"
 		)
 
 		RootCmd.Flags().String(longOpt, defaults.StatsdPort, desc(description, envVar))

--- a/internal/builtins/collector/linux/procfs/disk.go
+++ b/internal/builtins/collector/linux/procfs/disk.go
@@ -21,9 +21,11 @@ import (
 
 	"github.com/circonus-labs/circonus-agent/internal/builtins/collector"
 	"github.com/circonus-labs/circonus-agent/internal/config"
+	"github.com/circonus-labs/circonus-agent/internal/config/defaults"
 	"github.com/circonus-labs/circonus-agent/internal/tags"
 	cgm "github.com/circonus-labs/circonus-gometrics/v3"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 // Disk metrics from the Linux ProcFS
@@ -304,7 +306,11 @@ func (c *Disk) getSectorSize(dev string) uint64 {
 		return sz
 	}
 
-	fn := path.Join(string(os.PathSeparator), "sys", "block", dev, "queue", "physical_block_size")
+	sysFSPath := viper.GetString(config.KeyHostSys)
+	if sysFSPath == "" {
+		sysFSPath = defaults.HostSys
+	}
+	fn := path.Join(string(os.PathSeparator), sysFSPath, "block", dev, "queue", "physical_block_size")
 
 	c.logger.Debug().Str("fn", fn).Msg("checking for sector size")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,7 @@ type StatsD struct {
 	Disabled bool        `json:"disabled" yaml:"disabled" toml:"disabled"`
 	Group    StatsDGroup `json:"group" yaml:"group" toml:"group"`
 	Host     StatsDHost  `json:"host" yaml:"host" toml:"host"`
+	Addr     string      `join:"addr" yaml:"addr" toml:"addr"`
 	Port     string      `json:"port" yaml:"port" toml:"port"`
 }
 
@@ -219,7 +220,10 @@ const (
 	// KeyStatsdHostPrefix metrics prefixed with this string are considered "host" metrics
 	KeyStatsdHostPrefix = "statsd.host.metric_prefix"
 
-	// KeyStatsdPort port for statsd listener (note, address will always be 'localhost')
+	// KeyStatsdAddr address for statsd listener (default address will always be 'localhost')
+	KeyStatsdAddr = "statsd.addr"
+
+	// KeyStatsdPort port for statsd listener
 	KeyStatsdPort = "statsd.port"
 
 	// KeyStatsdEnableTCP enables statsd tcp listener

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -58,7 +58,10 @@ const (
 	// ReverseMaxConnRetry - how many times to retry persistently failing broker connection
 	ReverseMaxConnRetry = -1
 
-	// StatsdPort to listen, NOTE address is always localhost
+	// StatsdAddr to listen on
+	StatsdAddr = "localhost"
+
+	// StatsdPort to listen
 	StatsdPort = "8125"
 
 	// StatsdHostPrefix defines that metrics received through StatsD inteface

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -296,7 +296,7 @@ func (s *Server) encodeResponse(m *cgm.Metrics, w http.ResponseWriter, r *http.R
 	dumpDir := viper.GetString(config.KeyDebugDumpMetrics)
 	if dumpDir != "" {
 		dumpFile := filepath.Join(dumpDir, "metrics_"+time.Now().Format("20060102_150405")+".json")
-		if err := ioutil.WriteFile(dumpFile, jsonData, 0644); err != nil {
+		if err := ioutil.WriteFile(dumpFile, jsonData, 0644); err != nil { //nolint:gosec
 			s.logger.Error().
 				Err(err).
 				Str("file", dumpFile).

--- a/internal/statsd/statsd.go
+++ b/internal/statsd/statsd.go
@@ -144,7 +144,7 @@ func New(ctx context.Context) (*Server, error) {
 	}
 	port := viper.GetString(config.KeyStatsdPort)
 	if port == "" {
-		port = defaults.KeyStatsdPort
+		port = defaults.StatsdPort
 	}
 	address := net.JoinHostPort(addr, port)
 	// UDP listening address

--- a/internal/statsd/statsd.go
+++ b/internal/statsd/statsd.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/circonus-labs/circonus-agent/internal/config"
+	"github.com/circonus-labs/circonus-agent/internal/config/defaults"
 	"github.com/circonus-labs/circonus-agent/internal/release"
 	"github.com/circonus-labs/circonus-agent/internal/tags"
 	cgm "github.com/circonus-labs/circonus-gometrics/v3"
@@ -137,8 +138,15 @@ func New(ctx context.Context) (*Server, error) {
 		}
 	}
 
+	addr := viper.GetString(config.KeyStatsdAddr)
+	if addr == "" {
+		addr = defaults.StatsdAddr
+	}
 	port := viper.GetString(config.KeyStatsdPort)
-	address := net.JoinHostPort("localhost", port)
+	if port == "" {
+		port = defaults.KeyStatsdPort
+	}
+	address := net.JoinHostPort(addr, port)
 	// UDP listening address
 	if s.enableUDPListener {
 		addr, err := net.ResolveUDPAddr("udp", address)


### PR DESCRIPTION
* add: `--statsd-addr`, `CA_STATSD_ADDR` to explicitly specify an address that statsd should listen to (e.g. `--statsd-addr=0.0.0.0` for docker containers, so the port can be properly exposed).
* fix: procfs.disk use `HOST_SYS` if provided