### PR TITLE
v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.6
+
+* fix: `cpu_used` calculate average over collection interval (not aggregate)
+
 # v1.0.5
 
 * fix: pin `x/sys` to fix `cannot use type []byte as type []int8` issue for freeebsd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.0.6
 
 * fix: `cpu_used` calculate average over collection interval (not aggregate)
+* fix: increase max comm read timeouts to 6 (when waiting for command in reverse)
 
 # v1.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v1.0.6
 
+* add: `collector:cpu` - `num_cpu`, `processes`, `procs_runnable`, and `procs_blocked` for USE dashboard
 * fix: `cpu_used` calculate average over collection interval (not aggregate)
 * fix: increase max comm read timeouts to 6 (when waiting for command in reverse)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,14 +91,13 @@ Vagrant.configure('2') do |config|
         u18.vm.synced_folder '.', agent_src_path, owner: 'vagrant', group: 'vagrant'
         u18.vm.network 'private_network', ip: '192.168.100.200'
         u18.vm.provision 'shell', path: 'vprov/u18.sh', args: [go_url_base, go_ver]
-        u18.vbguest.auto_update = false
+        u18.vbguest.auto_update = true
     end
     #
     # ubuntu16 builder
     #
     config.vm.define 'u16', autostart: false do |u16|
         u16.vm.box = 'ubuntu/xenial64'
-        # u16.vm.box = 'maier/ubuntu-16.04-x86_64'
         u16.vm.provider 'virtualbox' do |vb|
             vb.name = 'u16_circonus-agent_build'
             vb.memory = '2048'
@@ -109,6 +108,22 @@ Vagrant.configure('2') do |config|
         u16.vm.network 'private_network', ip: '192.168.100.200'
         u16.vm.provision 'shell', path: 'vprov/u16.sh', args: [go_url_base, go_ver]
         u16.vbguest.auto_update = true
+    end
+    #
+    # ubuntu14 builder
+    #
+    config.vm.define 'u14', autostart: false do |u14|
+        u14.vm.box = 'ubuntu/trusty64'
+        u14.vm.provider 'virtualbox' do |vb|
+            vb.name = 'u14_circonus-agent_build'
+            vb.memory = '2048'
+            vb.cpus = 2
+            vb.customize [ "modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "./console.log")]
+        end
+        u14.vm.synced_folder '.', agent_src_path, owner: 'vagrant', group: 'vagrant'
+        u14.vm.network 'private_network', ip: '192.168.100.200'
+        u14.vm.provision 'shell', path: 'vprov/u14.sh', args: [go_url_base, go_ver]
+        u14.vbguest.auto_update = true
     end
 
     #

--- a/internal/builtins/collector/linux/procfs/cpu.go
+++ b/internal/builtins/collector/linux/procfs/cpu.go
@@ -155,8 +155,34 @@ func (c *CPU) Collect(ctx context.Context) error {
 		return errors.Wrap(err, c.pkgID)
 	}
 
+	_ = c.addMetric(&metrics, "", "num_cpu", "I", runtime.NumCPU(), tags.Tags{})
+
 	for _, line := range lines {
 		fields := strings.Fields(line)
+
+		switch fields[0] {
+		case "processes":
+			v, err := strconv.ParseInt(fields[1], 10, 64)
+			if err == nil {
+				_ = c.addMetric(&metrics, "", "processes", "I", v, tags.Tags{})
+			} else {
+				c.logger.Warn().Err(err).Str("line", line).Str("value", fields[1]).Msg("parsing int")
+			}
+		case "procs_running":
+			v, err := strconv.ParseInt(fields[1], 10, 64)
+			if err == nil {
+				_ = c.addMetric(&metrics, "", "procs_runnable", "I", v, tags.Tags{})
+			} else {
+				c.logger.Warn().Err(err).Str("line", line).Str("value", fields[1]).Msg("parsing int")
+			}
+		case "procs_blocked":
+			v, err := strconv.ParseInt(fields[1], 10, 64)
+			if err == nil {
+				_ = c.addMetric(&metrics, "", "procs_blocked", "I", v, tags.Tags{})
+			} else {
+				c.logger.Warn().Err(err).Str("line", line).Str("value", fields[1]).Msg("parsing int")
+			}
+		}
 
 		if !strings.HasPrefix(fields[0], c.id) {
 			continue

--- a/internal/builtins/collector/linux/procfs/cpu.go
+++ b/internal/builtins/collector/linux/procfs/cpu.go
@@ -26,9 +26,10 @@ import (
 // CPU metrics from the Linux ProcFS
 type CPU struct {
 	common
-	numCPU        float64 // number of cpus
-	clockNorm     float64 // cpu clock normalized to 100Hz tick rate
-	reportAllCPUs bool    // OPT report all cpus (vs just total) may be overridden in config file
+	numCPU        float64               // number of cpus
+	clockNorm     float64               // cpu clock normalized to 100Hz tick rate
+	reportAllCPUs bool                  // OPT report all cpus (vs just total) may be overridden in config file
+	lastRunValues map[string]lastValues // values from last run
 }
 
 // cpuOptions defines what elements can be overridden in a config file
@@ -43,12 +44,18 @@ type cpuOptions struct {
 	AllCPU  string `json:"report_all_cpus" toml:"report_all_cpus" yaml:"report_all_cpus"`
 }
 
+type lastValues struct {
+	all  float64
+	busy float64
+}
+
 // NewCPUCollector creates new procfs cpu collector
 func NewCPUCollector(cfgBaseName, procFSPath string) (collector.Collector, error) {
 	procFile := "stat"
 
 	c := CPU{
-		common: newCommon(NameCPU, procFSPath, procFile, tags.FromList(tags.GetBaseTags())),
+		common:        newCommon(NameCPU, procFSPath, procFile, tags.FromList(tags.GetBaseTags())),
+		lastRunValues: make(map[string]lastValues),
 	}
 
 	c.numCPU = float64(runtime.NumCPU())
@@ -200,7 +207,6 @@ func (c *CPU) parseCPU(fields []string) (string, *cgm.Metrics, error) {
 
 	metricType := "n" // resmon double
 
-	all := float64(0)
 	busy := float64(0)
 
 	userNormal, err := strconv.ParseFloat(fields[1], 64)
@@ -274,11 +280,7 @@ func (c *CPU) parseCPU(fields []string) (string, *cgm.Metrics, error) {
 		busy += guestNice
 	}
 
-	all = busy + idleNormal
-	used := (busy / all) * 100
-
 	metrics := cgm.Metrics{
-		"cpu_used":       cgm.Metric{Type: metricType, Value: used},
 		"cpu_user":       cgm.Metric{Type: metricType, Value: (userNormal / numCPU) / c.clockNorm},
 		"cpu_system":     cgm.Metric{Type: metricType, Value: (sys / numCPU) / c.clockNorm},
 		"cpu_idle":       cgm.Metric{Type: metricType, Value: (idleNormal / numCPU) / c.clockNorm},
@@ -289,28 +291,14 @@ func (c *CPU) parseCPU(fields []string) (string, *cgm.Metrics, error) {
 		"cpu_steal":      cgm.Metric{Type: metricType, Value: (steal / numCPU) / c.clockNorm},
 		"cpu_guest":      cgm.Metric{Type: metricType, Value: (guest / numCPU) / c.clockNorm},
 		"cpu_guest_nice": cgm.Metric{Type: metricType, Value: (guestNice / numCPU) / c.clockNorm},
-		// -- unused
-		// "cpu_user":              cgm.Metric{Type: metricType, Value: ((userNormal + userNice) / numCPU) / c.clockNorm},
-		// "cpu_kernel":            cgm.Metric{Type: metricType, Value: ((sys + guest + guestNice) / numCPU) / c.clockNorm},
-		// "cpu_idle":              cgm.Metric{Type: metricType, Value: ((idleNormal + steal) / numCPU) / c.clockNorm},
-		// "cpu_irq_hard": cgm.Metric{Type: metricType, Value: (irq / numCPU) / c.clockNorm},
-		// --- original below
-		// "cpu_used":              cgm.Metric{Type: metricType, Value: used},
-		// "cpu_user":              cgm.Metric{Type: metricType, Value: ((userNormal + userNice) / numCPU) / c.clockNorm},
-		// "cpu_user_normal":       cgm.Metric{Type: metricType, Value: (userNormal / numCPU) / c.clockNorm},
-		// "cpu_user_nice":         cgm.Metric{Type: metricType, Value: (userNice / numCPU) / c.clockNorm},
-		// "cpu_kernel":            cgm.Metric{Type: metricType, Value: ((sys + guest + guestNice) / numCPU) / c.clockNorm},
-		// "cpu_kernel_sys":        cgm.Metric{Type: metricType, Value: (sys / numCPU) / c.clockNorm},
-		// "cpu_kernel_guest":      cgm.Metric{Type: metricType, Value: (guest / numCPU) / c.clockNorm},
-		// "cpu_kernel_guest_nice": cgm.Metric{Type: metricType, Value: (guestNice / numCPU) / c.clockNorm},
-		// "cpu_idle":              cgm.Metric{Type: metricType, Value: ((idleNormal + steal) / numCPU) / c.clockNorm},
-		// "cpu_idle_normal":       cgm.Metric{Type: metricType, Value: (idleNormal / numCPU) / c.clockNorm},
-		// "cpu_idle_steal":        cgm.Metric{Type: metricType, Value: (steal / numCPU) / c.clockNorm},
-		// "cpu_wait_io":           cgm.Metric{Type: metricType, Value: (waitIO / numCPU) / c.clockNorm},
-		// "cpu_irq":               cgm.Metric{Type: metricType, Value: ((irq + softIRQ) / numCPU) / c.clockNorm},
-		// "cpu_irq_soft":          cgm.Metric{Type: metricType, Value: (softIRQ / numCPU) / c.clockNorm},
-		// "cpu_irq_hard":          cgm.Metric{Type: metricType, Value: (irq / numCPU) / c.clockNorm},
 	}
+
+	all := float64(busy + idleNormal)
+	if lrv, ok := c.lastRunValues[fields[0]]; ok {
+		used := ((busy - lrv.busy) / (all - lrv.all)) * 100
+		metrics["cpu_used"] = cgm.Metric{Type: metricType, Value: used}
+	}
+	c.lastRunValues[fields[0]] = lastValues{all: all, busy: busy}
 
 	return cpuID, &metrics, nil
 }

--- a/internal/reverse/connection/connection.go
+++ b/internal/reverse/connection/connection.go
@@ -101,7 +101,7 @@ const (
 	MaxDelaySeconds      = 60    // maximum amount of delay between attempts
 	MaxRequests          = -1    // max requests from broker before resetting connection, -1 = unlimited
 	MaxPayloadLen        = 65529 // max unsigned short - 6 (for header)
-	MaxCommTimeouts      = 5     // multiply by commTimeout, ensure >(broker polling interval) otherwise conn reset loop
+	MaxCommTimeouts      = 6     // multiply by commTimeout, ensure >(broker polling interval) otherwise conn reset loop
 	MinDelayStep         = 1     // minimum seconds to add on retry
 	MaxDelayStep         = 20    // maximum seconds to add on retry
 	ConfigRetryLimit     = 5     // if failed attempts > limit, force check reconfig (see if broker configuration changed)

--- a/package/build.sh
+++ b/package/build.sh
@@ -121,7 +121,7 @@ case $os_type in
         elif [[ -f /etc/lsb-release ]]; then
             install_target="install-ubuntu"
             source /etc/lsb-release
-            [[ $DISTRIB_RELEASE =~ ^(16|18|20)\.04$ ]] || { echo "unsupported Ubuntu release ($DISTRIB_RELEASE)"; exit 1; }
+            [[ $DISTRIB_RELEASE =~ ^(14|16|18|20)\.04$ ]] || { echo "unsupported Ubuntu release ($DISTRIB_RELEASE)"; exit 1; }
             os_name="ubuntu.${DISTRIB_RELEASE}"
             [[ -z "$(type -P $FPM)" ]] && { echo "unable to find '${FPM}' command in [$PATH]"; exit 1; }
         else

--- a/package/rhel/circonus-agent.spec.in
+++ b/package/rhel/circonus-agent.spec.in
@@ -8,9 +8,10 @@
 %define     app_dir     %{_prefix}/agent
 
 %if 0%{?el8}
-# perl is *optional* not required
-# rpmbuild autoreq will include it by default because of scripts with perl shebang
+# perl and python are *optional*, not required
+# rpmbuild autoreq will include by default because of scripts with perl|python shebang
 %define __requires_exclude perl
+%define __requires_exclude python
 # TODO: fix shebangs (e.g. python) to work from el6->el8 (on el8 mangle ERRORS 
 #       about using python2 or python3 instead of bare python)
 %undefine __brp_mangle_shebangs 

--- a/vbuild.sh
+++ b/vbuild.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-distros="el8 el7 el6 u20 u18 u16 fb12 fb11"
+distros="el8 el7 el6 u20 u18 u16 u14 fb12 fb11"
 [[ -n "$1" ]] && distros="${@:1}"
 
 src_dir="~/godev/src/github.com/circonus-labs/circonus-agent/package"

--- a/vprov/u14.sh
+++ b/vprov/u14.sh
@@ -10,6 +10,10 @@ echo "Installing needed packages (e.g. git, go, etc.)"
 apt-get update
 apt-get --assume-yes install git ruby ruby-dev build-essential libpcap-dev
 
+echo "Installing ruby2.3 for FPM"
+apt-add-repository -y ppa:brightbox/ruby-ng
+apt-get -y install ruby2.3 ruby2.3-dev
+
 echo "Installing FPM gem"
 gem install --no-ri --no-rdoc fpm
 


### PR DESCRIPTION
* fix: `cpu_used` calculate average over collection interval (not aggregate)
* fix: increase max comm read timeouts to 6 (when waiting for command in reverse)
* upd: exclude python from el8 requires (it's optional)
* upd: add u14 back for builds
