### PR TITLE
v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.7
+
+* upd: when multiple bundles returned from API, identify the one created by agent (vs. created by NAD/cosi)
+* upd: pre-seed procfs/cpu for `cpu_used`
+
 # v1.0.6
 
 * add: `collector:cpu` - `num_cpu`, `processes`, `procs_runnable`, and `procs_blocked` for USE dashboard

--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ The circonus-agent is intended to be a drop-in replacement for NAD. There is, ho
 
 # Releases
 
-[Releases](https://github.com/circonus-labs/circonus-agent/releases) provide pre-built binaries for Linux (arm and x86_64), FreeBSD (x86_64), Solaris (x86_64), and Windows (x86_64).
+* Binary only [releases](https://github.com/circonus-labs/circonus-agent/releases) provide pre-built binaries for Linux (arm and x86_64), FreeBSD (x86_64), Solaris (x86_64), and Windows (x86_64).
+* RPM and DEB [packages](https://setup.circonus.com/packages/) for manual installations with plugins included
+* Docker [images](https://hub.docker.com/r/circonuslabs/circonus-agent/tags)
 
 # Install
 
 ## Automated via [cosi](https://github.com/circonus-labs/cosi-tool)
+
+> Note: installs v0 release of the circonus-agent, not the v1 release
 
 ```sh
 curl -sSL https://setup.circonus.com/install | bash \
@@ -87,8 +91,8 @@ enabled = true
 ## Manual, stand-alone (non-windows)
 
 1. `mkdir -p /opt/circonus/agent`
-1. Download [latest release](../../releases/latest) from repository
-1. Extract archive into `/opt/circonus/agent`
+1. Download [latest release](../../releases/latest) from repository or RPM/DEB/TGZ [package](https://setup.circonus.com/packages/)
+1. Extract archive into `/opt/circonus/agent` or manually install os package
 1. Create a [config](https://github.com/circonus-labs/circonus-agent/blob/master/etc/README.md#main-configuration) (see minimal example below) or use command line parameters
 1. Optionally, modify and install a [service configuration](service/)
 

--- a/internal/builtins/collector/linux/procfs/cpu.go
+++ b/internal/builtins/collector/linux/procfs/cpu.go
@@ -323,6 +323,9 @@ func (c *CPU) parseCPU(fields []string) (string, *cgm.Metrics, error) {
 	if lrv, ok := c.lastRunValues[fields[0]]; ok {
 		used := ((busy - lrv.busy) / (all - lrv.all)) * 100
 		metrics["cpu_used"] = cgm.Metric{Type: metricType, Value: used}
+	} else {
+		used := (busy / all) * 100
+		metrics["cpu_used"] = cgm.Metric{Type: metricType, Value: used}
 	}
 	c.lastRunValues[fields[0]] = lastValues{all: all, busy: busy}
 

--- a/internal/builtins/collector/linux/procfs/procfs.go
+++ b/internal/builtins/collector/linux/procfs/procfs.go
@@ -9,6 +9,7 @@
 package procfs
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"regexp"
@@ -41,7 +42,7 @@ var (
 )
 
 // New creates new ProcFS collector
-func New() ([]collector.Collector, error) {
+func New(ctx context.Context) ([]collector.Collector, error) {
 	none := []collector.Collector{}
 
 	if runtime.GOOS != "linux" {
@@ -76,6 +77,9 @@ func New() ([]collector.Collector, error) {
 				l.Error().Str("name", name).Err(err).Msg(initErrMsg)
 				continue
 			}
+			// prime the cpu counters for cpu_used
+			_ = c.Collect(ctx)
+			_ = c.Flush()
 			collectors = append(collectors, c)
 
 		case NameDisk, "diskstats": // cover old, deprecated name

--- a/internal/builtins/collector/linux/procfs/procfs_test.go
+++ b/internal/builtins/collector/linux/procfs/procfs_test.go
@@ -8,6 +8,7 @@
 package procfs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/circonus-labs/circonus-agent/internal/config"
@@ -22,7 +23,7 @@ func TestNew(t *testing.T) {
 		"procfs/disk",
 	})
 
-	c, err := New()
+	c, err := New(context.Background())
 	if err != nil {
 		t.Fatalf("expected NO error, got (%s)", err)
 	}

--- a/internal/builtins/configure_linux.go
+++ b/internal/builtins/configure_linux.go
@@ -25,7 +25,7 @@ func (b *Builtins) configure(ctx context.Context) error {
 		//       builtins are used by cosi visuals. these are _direct_ replacements
 		//       for the original NAD plugins of the same name
 		l.Debug().Msg("calling procfs.New")
-		collectors, err := procfs.New()
+		collectors, err := procfs.New(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* upd: when multiple bundles returned from API, identify the one created by agent (vs. created by NAD/cosi)
* upd: pre-seed procfs/cpu for `cpu_used`
