### PR TITLE
v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v1.0.9
+
+* add: `--check-update|-U` (check.update) force update of **ALL** configurable check bundle attributes:
+  * config.url
+  * target
+  * display name
+  * period
+  * timeout
+  * metric filters
+  * check tags
+  * broker cid if explicit (Meaning, agent will not select a new one for an existing check. It will only update if a broker id/cid is provided in the configuration)
+  * NOTE: check-update takes precedence over check-update-metric-filters
+* add: `--check-period` (check.period) default 60
+* add: `--check-timeout` (check.timeout) default 10
+
 # v1.0.8
 
 * add: `--check-metric-filter-file` external json file with metric filters

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -415,6 +415,25 @@ func init() {
 
 	{
 		const (
+			key         = config.KeyCheckUpdate
+			longOpt     = "check-update"
+			shortOpt    = "U"
+			envVar      = release.ENVPREFIX + "_CHECK_UPDATE"
+			description = "Force check bundle update at start (with all configurable check bundle attributes)"
+		)
+
+		RootCmd.Flags().BoolP(longOpt, shortOpt, defaults.CheckCreate, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaults.CheckCreate)
+	}
+
+	{
+		const (
 			key         = config.KeyCheckTarget
 			longOpt     = "check-target"
 			shortOpt    = "T"
@@ -559,20 +578,37 @@ func init() {
 
 	{
 		const (
-			key         = config.KeyCheckMetricRefreshTTL
-			longOpt     = "check-metric-refresh-ttl"
-			envVar      = release.ENVPREFIX + "_CHECK_METRIC_REFRESH_TTL"
-			description = "Refresh check metrics TTL"
+			key         = config.KeyCheckPeriod
+			longOpt     = "check-period"
+			envVar      = release.ENVPREFIX + "_CHECK_PERIOD"
+			description = "When broker requests metrics [10-300] seconds"
 		)
+		defaultValue := defaults.CheckPeriod
 
-		RootCmd.Flags().String(longOpt, defaults.CheckMetricRefreshTTL, desc(description, envVar))
+		RootCmd.Flags().Uint(longOpt, defaultValue, desc(description, envVar))
 		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
 			bindFlagError(longOpt, err)
 		}
 		if err := viper.BindEnv(key, envVar); err != nil {
 			bindEnvError(envVar, err)
 		}
-		viper.SetDefault(key, defaults.CheckMetricRefreshTTL)
+	}
+	{
+		const (
+			key         = config.KeyCheckTimeout
+			longOpt     = "check-timeout"
+			envVar      = release.ENVPREFIX + "_CHECK_TIMEOUT"
+			description = "Timeout when broker requests metrics [0-300] seconds"
+		)
+		defaultValue := defaults.CheckTimeout
+
+		RootCmd.Flags().Float64(longOpt, defaultValue, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
 	}
 
 	//
@@ -1201,6 +1237,27 @@ func init() {
 		}
 		viper.SetDefault(key, defaults.CheckMetricStatePath)
 	}
+
+	{
+		const (
+			key         = config.KeyCheckMetricRefreshTTL
+			longOpt     = "check-metric-refresh-ttl"
+			envVar      = release.ENVPREFIX + "_CHECK_METRIC_REFRESH_TTL"
+			description = "Refresh check metrics TTL"
+		)
+
+		RootCmd.Flags().String(longOpt, defaults.CheckMetricRefreshTTL, desc(description, envVar))
+		flag := RootCmd.Flags().Lookup(longOpt)
+		flag.Hidden = true
+		if err := viper.BindPFlag(key, flag); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaults.CheckMetricRefreshTTL)
+	}
+
 }
 
 // initLogging initializes zerolog

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,19 +42,22 @@ type ReverseCreateCheckOptions struct {
 
 // Check defines the check parameters
 type Check struct {
-	Broker              string `json:"broker" yaml:"broker" toml:"broker"`
-	BundleID            string `mapstructure:"bundle_id" json:"bundle_id" yaml:"bundle_id" toml:"bundle_id"`
-	Create              bool   `mapstructure:"create" json:"create" yaml:"create" toml:"create"`
-	MetricFilters       string `mapstructure:"metric_filters" json:"metric_filters" yaml:"metric_filters" toml:"metric_filters"` // needs to be json embedded in a string because rules are positional
-	MetricFilterFile    string `mapstructure:"metric_filter_file" json:"metric_filter_file" yaml:"metric_filter_file" toml:"metric_filter_file"`
-	UpdateMetricFilters bool   `mapstructure:"update_metric_filters" json:"update_metric_filters" yaml:"update_metric_filters" toml:"update_metric_filters"`
-	MetricRefreshTTL    string `mapstructure:"metric_refresh_ttl" json:"metric_refresh_ttl" yaml:"metric_refresh_ttl" toml:"metric_refresh_ttl"`
-	MetricStreamtags    bool   `mapstructure:"metric_streamtags" json:"metric_streamtags" yaml:"metric_streamtags" toml:"metric_streamtags"`
-	Tags                string `json:"tags" yaml:"tags" toml:"tags"`
-	Target              string `mapstructure:"target" json:"target" yaml:"target" toml:"target"`
-	Title               string `json:"title" yaml:"title" toml:"title"`
+	Broker              string  `json:"broker" yaml:"broker" toml:"broker"`
+	BundleID            string  `mapstructure:"bundle_id" json:"bundle_id" yaml:"bundle_id" toml:"bundle_id"`
+	Create              bool    `mapstructure:"create" json:"create" yaml:"create" toml:"create"`
+	MetricFilterFile    string  `mapstructure:"metric_filter_file" json:"metric_filter_file" yaml:"metric_filter_file" toml:"metric_filter_file"`
+	MetricFilters       string  `mapstructure:"metric_filters" json:"metric_filters" yaml:"metric_filters" toml:"metric_filters"` // needs to be json embedded in a string because rules are positional
+	MetricStreamtags    bool    `mapstructure:"metric_streamtags" json:"metric_streamtags" yaml:"metric_streamtags" toml:"metric_streamtags"`
+	Period              uint    `json:"period" toml:"period" yaml:"period"`
+	Tags                string  `json:"tags" yaml:"tags" toml:"tags"`
+	Target              string  `mapstructure:"target" json:"target" yaml:"target" toml:"target"`
+	Timeout             float64 `json:"timeout" toml:"timeout" yaml:"timeout"`
+	Title               string  `json:"title" yaml:"title" toml:"title"`
+	Update              bool    `json:"update" toml:"update" yaml:"update"`
+	UpdateMetricFilters bool    `mapstructure:"update_metric_filters" json:"update_metric_filters" yaml:"update_metric_filters" toml:"update_metric_filters"`
 	// hide deprecated config settings
 	EnableNewMetrics bool   `json:"-" yaml:"-" toml:"-"`
+	MetricRefreshTTL string `json:"-" yaml:"-" toml:"-"`
 	MetricStateDir   string `json:"-" yaml:"-" toml:"-"`
 }
 
@@ -289,8 +292,17 @@ const (
 	// KeyCheckUpdateMetricFIlters force update of check with configured metric filters on start
 	KeyCheckUpdateMetricFilters = "check.update_metric_filters"
 
+	// KeyCheckPeriod when broker requests metrics
+	KeyCheckPeriod = "check.period"
+
+	// KeyCheckTimeout broker timeout when requesting metrics
+	KeyCheckTimeout = "check.timeout"
+
 	// KeyCheckCreate toggles creating a new check bundle when a check bundle id is not supplied
 	KeyCheckCreate = "check.create"
+
+	// KeyCheckUpdate forces updating all configurable check bundle attributes
+	KeyCheckUpdate = "check.update"
 
 	// KeyCheckBroker a specific broker ID to use when creating a new check bundle
 	KeyCheckBroker = "check.broker"

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -175,6 +175,14 @@ var (
 	//                          with whatever rules are in the agent configuration (or external metric filters file)
 	CheckUpdateMetricFilters = false
 
+	// CheckPeriod how often broker requests metrics
+	CheckPeriod = uint(60)
+	// CheckTimeout broker timeout when requesting metrics
+	CheckTimeout = float64(10)
+
+	// CheckUpdate forces updating all configurable check attributes
+	CheckUpdate = false
+
 	// SSLCertFile returns the deefault ssl cert file name
 	SSLCertFile = "" // (e.g. /opt/circonus/agent/etc/agent.pem)
 


### PR DESCRIPTION
* add: `--check-update|-U` (check.update) force update of **ALL** configurable check bundle attributes:
  * config.url
  * target
  * display name
  * period
  * timeout
  * metric filters
  * check tags
  * broker cid if explicit (Meaning, agent will not select a new one for an existing check. It will only update if a broker id/cid is provided in the configuration)
  * NOTE: check-update takes precedence over check-update-metric-filters
* add: `--check-period` (check.period) default 60
* add: `--check-timeout` (check.timeout) default 10
