### PR TITLE
"metric reset" disable via http header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,12 @@ module github.com/circonus-labs/circonus-agent
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
-	github.com/circonus-labs/circonus-gometrics/v3 v3.0.0
+	github.com/circonus-labs/circonus-gometrics/v3 v3.0.2
 	github.com/circonus-labs/circonusllhist v0.1.4
 	github.com/circonus-labs/go-apiclient v0.7.6
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gojuno/minimock/v3 v3.0.6
 	github.com/hashicorp/go-hclog v0.10.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.6.4 // indirect
 	github.com/maier/go-appstats v0.2.0
 	github.com/pelletier/go-toml v1.8.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/circonus-labs/circonus-gometrics/v3 v3.0.0 h1:5hbWwgfrYaSNCe+eKPGo457QiCe4T5+CfvY+bFGZBNw=
 github.com/circonus-labs/circonus-gometrics/v3 v3.0.0/go.mod h1:1K33fx/wP96fC1uc7ZEp3BoLafJhL0kpjejIXpQHyLM=
+github.com/circonus-labs/circonus-gometrics/v3 v3.0.2 h1:3HWtWWPpHUuBgjALLtE7PaQLEcAmxhmZjtYOoNofa7A=
+github.com/circonus-labs/circonus-gometrics/v3 v3.0.2/go.mod h1:hbHb81YGFfRAgDZHE8J5kws/aDP1D40tkaTnhVfnqSw=
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/circonus-labs/circonusllhist v0.1.4 h1:G5qJPuD16akpIXMUR7KcfBvrQOVm95+qyqUm+SEAZks=
@@ -120,6 +122,8 @@ github.com/hashicorp/go-retryablehttp v0.5.4 h1:1BZvpawXoJCWX6pNtow9+rpEj+3itIlu
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
+github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -145,8 +145,14 @@ func (s *Server) run(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			conduitID := "receiver"
 			numMetrics := 0
+			reset := strings.ToLower(r.Header.Get("x-circonus-receiver-reset"))
 			s.logger.Debug().Str("conduit_id", conduitID).Msg("start")
-			receiverMetrics := receiver.Flush()
+			var receiverMetrics *cgm.Metrics
+			if reset == "false" {
+				receiverMetrics = receiver.FlushNoReset()
+			} else {
+				receiverMetrics = receiver.Flush()
+			}
 			if receiverMetrics != nil && len(*receiverMetrics) > 0 {
 				numMetrics = len(*receiverMetrics)
 				conduitCh <- conduit{id: conduitID, metrics: receiverMetrics}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -420,7 +420,7 @@ func TestPromOutput(t *testing.T) {
 		t.Fatal("expected NOT nil")
 	}
 
-	t.Logf("GET /prom -> %d (w/o metrics)", http.StatusNoContent)
+	t.Logf("GET /prom -> %d (w/o metrics)", http.StatusOK)
 	{
 		_ = httptest.NewRequest("GET", "/prom", nil)
 		w := httptest.NewRecorder()
@@ -430,8 +430,8 @@ func TestPromOutput(t *testing.T) {
 		resp := w.Result()
 		resp.Body.Close()
 
-		if resp.StatusCode != http.StatusNoContent {
-			t.Fatalf("expected %d, got %d", http.StatusNoContent, resp.StatusCode)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, resp.StatusCode)
 		}
 	}
 

--- a/internal/server/receiver/receiver.go
+++ b/internal/server/receiver/receiver.go
@@ -85,6 +85,11 @@ func Flush() *cgm.Metrics {
 	return metrics.FlushMetrics()
 }
 
+func FlushNoReset() *cgm.Metrics {
+	_ = initCGM()
+	return metrics.FlushMetricsNoReset()
+}
+
 // Parse handles incoming PUT/POST requests
 func Parse(id string, data io.Reader) error {
 	if err := initCGM(); err != nil {

--- a/internal/server/receiver/receiver_test.go
+++ b/internal/server/receiver/receiver_test.go
@@ -46,6 +46,41 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+func TestFlushNoReset(t *testing.T) {
+	t.Log("Testing FlushNoReset")
+
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	t.Log("\tno metrics")
+	{
+		m := FlushNoReset()
+		if len(*m) != 0 {
+			t.Fatalf("expected 0 metrics, got %d", len(*m))
+		}
+	}
+
+	t.Log("\tw/metric(s)")
+	{
+		err := initCGM()
+		if err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+		metrics.SetText("test", "test")
+
+		m := FlushNoReset()
+		if len(*m) != 1 {
+			t.Fatalf("expected 1 metric, got %d", len(*m))
+		}
+		m = FlushNoReset()
+		if len(*m) != 1 {
+			t.Fatalf("expected 1 metric, got %d", len(*m))
+		}
+		// this removes the test metric,
+		// since TestParse expects no metrics, and tests share a metric store
+		_ = Flush()
+	}
+}
+
 func TestParse(t *testing.T) {
 	t.Log("Testing Parse")
 

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -144,8 +144,8 @@ func TestRouter(t *testing.T) {
 			{"GET", "/inventory/", http.StatusOK},
 			{"GET", "/stats", http.StatusOK},
 			{"GET", "/stats/", http.StatusOK},
-			{"GET", "/prom", http.StatusNoContent},
-			{"GET", "/prom/", http.StatusNoContent},
+			{"GET", "/prom", http.StatusOK},
+			{"GET", "/prom/", http.StatusOK},
 		}
 		// zerolog.SetGlobalLevel(zerolog.DebugLevel)
 


### PR DESCRIPTION
Our use case for this is post-deploy verification testing of metrics pushed to `/write` - we want to see the metric data, but don't want our test to consume it, causing a dip in metrics and false positive alerts.

I changed a couple tests in the same directory as the other files I was touching to expect `http.StatusOK` instead of `http.StatusNoContent` since that's what the endpoints were returning. I can revert that if you prefer to address those tests separately.