### PR TITLE
v1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.11
+
+* upd: if multiple checks found matching criteria (active,json:nad,target) and none match the agent, return result such that a check will be created (if create check is enabled) - note, this does present the possiblity of multiple checks being created if the notes are altered in such a way that the agent is not able to determine it created the check
+
 # v1.0.10
 
 * upd: remove rpm conflict with NAD

--- a/internal/check/bundle/bundle.go
+++ b/internal/check/bundle/bundle.go
@@ -378,6 +378,10 @@ func (cb *Bundle) findCheckBundle() (*apiclient.CheckBundle, int, error) {
 				matched++
 			}
 		}
+		if matched == 0 {
+			cb.logger.Warn().Int("found", found).Int("matched", matched).Str("criteria", string(criteria)).Msgf("found multiple checks matching critera, none created by %s", release.NAME)
+			return nil, found, errors.Errorf("multiple checks (%d) found matching criteria (%s), none created by %s", found, string(criteria), release.NAME)
+		}
 		if matched == 1 {
 			cb.logger.Warn().Int("found", found).Str("bundle", (*bundles)[idx].CID).Msgf("multiple checks found, using one created by %s", release.NAME)
 			return &(*bundles)[idx], matched, nil


### PR DESCRIPTION
* upd: if multiple checks found matching criteria (active,json:nad,target) and none match the agent, return result such that a check will be created (if create check is enabled) - note, this does present the possiblity of multiple checks being created if the notes are altered in such a way that the agent is not able to determine it created the check
