### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v2.0.0
+
+Note: For automatic host dashboards a new check type is being used. This makes this update **not** backwards compatible. It will create a new check of the correct type.
+
+* add: new check types for automatic dashboard
+* add: internal agent metrics `agent_*` for new dashboard
+* add: host based check tags for new dashboard
+* add: check bundle tag updater
+* add: wmi/system builtin collector
+* add: settings for cpu and memory utilization thresholds for `process_threshold` metrics
+* fix: various tests for new features
+* upd: silently ignore prom config missing for builtin, just disable quietly
+* upd: config loader, return `os.ErrNotExist` wrapped for `errors.Is`
+
 # v1.2.0
 
 * fix: use api ca file if specified for check api client

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Circonus Agent
 
-Version 1.x of the circonus-agent only supports metrics with stream tags (if it is _dropped in_ an existing NAD install, the metric names will change). If metric name continuity is required, use the v0 circonus-agent releases.
+> NOTE: Version 2.x of the circonus-agent uses a new check type in order to support the new dynamic host dashboards. It will create a new check if it is installed over any prior version of the circonus-agent or NAD.
 
 # Features
 
-1. Replacement for NAD, written in Go - note, v0.x only
-1. Builtin metric [collectors](#builtin-collectors) -- the default Linux builtins emit the common metrics needed for cosi visuals (graphs, worksheets, & dashboards)
+1. Builtin metric [collectors](#builtin-collectors) -- the default Linux builtins emit the common metrics needed for the dynamic host dashboard
 1. [Plugin](#plugins) architecture for local metric collection
 1. Local HTTP [Receiver](#receiver) for POST/PUT metric collection
 1. Local [StatsD](#statsd) listener for application metrics

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Version 1.x of the circonus-agent only supports metrics with stream tags (if it 
 
 # Install
 
+<!---
 ## Automated via [cosi](https://github.com/circonus-labs/cosi-tool)
 
 > Note: installs v0 release of the circonus-agent, not the v1 release
@@ -86,13 +87,14 @@ bundle_id = "cosi" # use cosi system check bundle
 [reverse]
 enabled = true
 ```
+--->
 
 ## Manual, stand-alone (non-windows)
 
 1. `mkdir -p /opt/circonus/agent`
 1. Download [latest release](../../releases/latest) from repository or RPM/DEB/TGZ [package](https://setup.circonus.com/packages/)
 1. Extract archive into `/opt/circonus/agent` or manually install os package
-1. Create a [config](https://github.com/circonus-labs/circonus-agent/blob/master/etc/README.md#main-configuration) (see minimal example below) or use command line parameters
+1. Create a [config](https://github.com/circonus-labs/circonus-agent/blob/master/etc/README.md#main-configuration) or use command line parameters
 1. Optionally, modify and install a [service configuration](service/)
 
 ## Manual, stand-alone (windows)
@@ -100,7 +102,7 @@ enabled = true
 1. Create a directory (e.g. `md C:\agent`)
 1. Download [latest release](../../releases/latest) from repository
 1. Unzip archive into directory created in step 1
-1. Create a [config](https://github.com/circonus-labs/circonus-agent/blob/master/etc/README.md#main-configuration) (see minimal example below) or use command line parameters
+1. Create a [config](https://github.com/circonus-labs/circonus-agent/blob/master/etc/README.md#main-configuration) or use command line parameters
 1. Optionally, create a service (for example, [using PowerShell](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-service?view=powershell-7&viewFallbackFrom=powershell-3.0))
 
 ## Docker

--- a/api/get_test.go
+++ b/api/get_test.go
@@ -38,7 +38,7 @@ func TestGet(t *testing.T) {
 		expectedErr string
 	}{
 		{"invalid path (empty)", "", true, "invalid request path (empty)"},
-		{"invalid path (bad)", "/%/%", true, "creating request url: parse /%/%: invalid URL escape \"%/%\""},
+		{"invalid path (bad)", "/%/%", true, `creating request url: parse "/%/%": invalid URL escape "%/%"`},
 		{"invalid path (not found)", "/not_found", true, "404 Not Found - " + ts.URL + "/not_found - Not Found"},
 		{"valid", "/valid", false, ""},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1221,6 +1221,44 @@ func init() {
 		viper.SetDefault(key, defaultValue)
 	}
 
+	// Threshold for CPU and Memory utilization to include process metric
+	{
+		const (
+			key          = config.KeyCPUThreshold
+			longOpt      = "threshold-hicpu"
+			envVar       = release.ENVPREFIX + "_THRESHOLD_HICPU"
+			description  = "High CPU utilization percentage to include process metric [-1=disabled]"
+			defaultValue = defaults.CPUThreshold
+		)
+
+		RootCmd.Flags().Float32(longOpt, defaultValue, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+	{
+		const (
+			key          = config.KeyMemThreshold
+			longOpt      = "threshold-himem"
+			envVar       = release.ENVPREFIX + "_THRESHOLD_HIMEM"
+			description  = "High memory utilization percentage to include process metric [-1=disabled]"
+			defaultValue = defaults.MemThreshold
+		)
+
+		RootCmd.Flags().Float32(longOpt, defaultValue, desc(description, envVar))
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+
 	{
 		const (
 			key          = config.KeyShowVersion

--- a/internal/builtins/builtins.go
+++ b/internal/builtins/builtins.go
@@ -54,9 +54,13 @@ func New(ctx context.Context) (*Builtins, error) {
 	if err != nil {
 		b.logger.Warn().Err(err).Msg("prom collector, disabling")
 	} else {
-		b.logger.Info().Str("id", "prom").Msg("enabled builtin")
-		b.collectors[prom.ID()] = prom
-		_ = appstats.IncrementInt("builtins.total")
+		// presence of a config is what enables this plugin
+		// if no error, and no config both `prom` and `err` will be nil, so silently disable
+		if prom != nil {
+			b.logger.Info().Str("id", "prom").Msg("enabled builtin")
+			b.collectors[prom.ID()] = prom
+			_ = appstats.IncrementInt("builtins.total")
+		}
 	}
 
 	return &b, nil

--- a/internal/builtins/collector/prometheus/prometheus.go
+++ b/internal/builtins/collector/prometheus/prometheus.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"regexp"
 	"sync"
@@ -79,9 +80,13 @@ func New(cfgBaseName string) (collector.Collector, error) {
 		cfgBaseName = path.Join(defaults.EtcPath, "prometheus_collector")
 	}
 
+	// a configuration file being found is what enables this plugin
 	var opts promOptions
 	err := config.LoadConfigFile(cfgBaseName, &opts)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil // if none found, return nothing
+		}
 		return nil, errors.Wrapf(err, "%s config", c.pkgID)
 	}
 

--- a/internal/builtins/collector/prometheus/prometheus_test.go
+++ b/internal/builtins/collector/prometheus/prometheus_test.go
@@ -73,17 +73,19 @@ func TestNew(t *testing.T) {
 
 	t.Log("no config spec (force default)")
 	{
-		_, err := New("")
-		if err == nil {
-			t.Fatal("expected error")
+		p, err := New("")
+		if p != nil && err != nil {
+			t.Fatalf("expected no error and no prom instance -- got %v %s", p, err)
+			// t.Fatal("expected error")
 		}
 	}
 
 	t.Log("missing config file")
 	{
-		_, err := New(path.Join("testdata", "missing"))
-		if err == nil {
-			t.Fatal("expected error")
+		p, err := New(path.Join("testdata", "missing"))
+		if p != nil && err != nil {
+			t.Fatalf("expected no error and no prom instance -- got %v %s", p, err)
+			// t.Fatal("expected error")
 		}
 	}
 

--- a/internal/builtins/collector/windows/wmi/system.go
+++ b/internal/builtins/collector/windows/wmi/system.go
@@ -1,0 +1,174 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build windows
+
+package wmi
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/StackExchange/wmi"
+	"github.com/circonus-labs/circonus-agent/internal/builtins/collector"
+	"github.com/circonus-labs/circonus-agent/internal/config"
+	"github.com/circonus-labs/circonus-agent/internal/tags"
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type Win32_PerfFormattedData_PerfOS_System struct {
+	Caption                     string
+	Description                 string
+	Name                        string
+	FileControlBytesPerSec      uint64
+	FileReadBytesPerSec         uint64
+	FileWriteBytesPerSec        uint64
+	Frequency_Object            uint64
+	Frequency_PerfTime          uint64
+	Frequency_Sys100NS          uint64
+	SystemUpTime                uint64
+	Timestamp_Object            uint64
+	Timestamp_PerfTime          uint64
+	Timestamp_Sys100NS          uint64
+	AlignmentFixupsPerSec       uint32
+	ContextSwitchesPerSec       uint32
+	ExceptionDispatchesPerSec   uint32
+	FileControlOperationsPerSec uint32
+	FileDataOperationsPerSec    uint32
+	FileReadOperationsPerSec    uint32
+	FileWriteOperationsPerSec   uint32
+	FloatingEmulationsPerSec    uint32
+	PercentRegistryQuotaInUse   uint32
+	Processes                   uint32
+	ProcessorQueueLength        uint32
+	SystemCallsPerSec           uint32
+	Threads                     uint32
+}
+
+// System metrics from the Windows Management Interface (wmi)
+type System struct {
+	wmicommon
+}
+
+// systemOptions defines what elements can be overridden in a config file
+type systemOptions struct {
+	ID              string `json:"id" toml:"id" yaml:"id"`
+	MetricNameRegex string `json:"metric_name_regex" toml:"metric_name_regex" yaml:"metric_name_regex"`
+	MetricNameChar  string `json:"metric_name_char" toml:"metric_name_char" yaml:"metric_name_char"`
+	RunTTL          string `json:"run_ttl" toml:"run_ttl" yaml:"run_ttl"`
+}
+
+// NewSystemCollector creates new wmi collector
+func NewSystemCollector(cfgBaseName string) (collector.Collector, error) {
+	c := System{}
+	c.id = "system"
+	c.pkgID = pkgName + "." + c.id
+	c.logger = log.With().Str("pkg", pkgName).Str("id", c.id).Logger()
+	c.metricNameChar = defaultMetricChar
+	c.metricNameRegex = defaultMetricNameRegex
+	c.baseTags = tags.FromList(tags.GetBaseTags())
+
+	if cfgBaseName == "" {
+		return &c, nil
+	}
+
+	var cfg systemOptions
+	err := config.LoadConfigFile(cfgBaseName, &cfg)
+	if err != nil {
+		if strings.Contains(err.Error(), "no config found matching") {
+			return &c, nil
+		}
+		c.logger.Warn().Err(err).Str("file", cfgBaseName).Msg("loading config file")
+		return nil, errors.Wrapf(err, "%s config", c.pkgID)
+	}
+
+	c.logger.Debug().Interface("config", cfg).Msg("loaded config")
+
+	if cfg.ID != "" {
+		c.id = cfg.ID
+	}
+
+	if cfg.MetricNameRegex != "" {
+		rx, err := regexp.Compile(cfg.MetricNameRegex)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%s compile metric_name_regex", c.pkgID)
+		}
+		c.metricNameRegex = rx
+	}
+
+	if cfg.MetricNameChar != "" {
+		c.metricNameChar = cfg.MetricNameChar
+	}
+
+	if cfg.RunTTL != "" {
+		dur, err := time.ParseDuration(cfg.RunTTL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%s parsing run_ttl", c.pkgID)
+		}
+		c.runTTL = dur
+	}
+
+	return &c, nil
+}
+
+// Collect metrics from the wmi resource
+func (c *System) Collect(ctx context.Context) error {
+	metrics := cgm.Metrics{}
+
+	c.Lock()
+
+	if c.runTTL > time.Duration(0) {
+		if time.Since(c.lastEnd) < c.runTTL {
+			c.logger.Warn().Msg(collector.ErrTTLNotExpired.Error())
+			c.Unlock()
+			return collector.ErrTTLNotExpired
+		}
+	}
+	if c.running {
+		c.logger.Warn().Msg(collector.ErrAlreadyRunning.Error())
+		c.Unlock()
+		return collector.ErrAlreadyRunning
+	}
+
+	c.running = true
+	c.lastStart = time.Now()
+	c.Unlock()
+
+	var dst []Win32_PerfFormattedData_PerfOS_System
+	qry := wmi.CreateQuery(dst, "")
+	if err := wmi.Query(qry, &dst); err != nil {
+		c.logger.Error().Err(err).Str("query", qry).Msg("wmi query error")
+		c.setStatus(metrics, err)
+		return errors.Wrap(err, c.pkgID)
+	}
+
+	metricType := "L"
+	tagUnitsPercent := cgm.Tag{Category: "units", Value: "percent"}
+	for _, item := range dst {
+		_ = c.addMetric(&metrics, "", "AlignmentFixupsPerSec", metricType, item.AlignmentFixupsPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "ContextSwitchesPerSec", metricType, item.ContextSwitchesPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "ExceptionDispatchesPerSec", metricType, item.ExceptionDispatchesPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FileControlBytesPerSec", metricType, item.FileControlBytesPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FileControlOperationsPerSec", metricType, item.FileControlOperationsPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FileDataOperationsPerSec", metricType, item.FileDataOperationsPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FileReadBytesPerSec", metricType, item.FileReadBytesPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FileReadOperationsPerSec", metricType, item.FileReadOperationsPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FileWriteBytesPerSec", metricType, item.FileWriteBytesPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FileWriteOperationsPerSec", metricType, item.FileWriteOperationsPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "FloatingEmulationsPerSec", metricType, item.FloatingEmulationsPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "PercentRegistryQuotaInUse", metricType, item.PercentRegistryQuotaInUse, cgm.Tags{tagUnitsPercent})
+		_ = c.addMetric(&metrics, "", "Processes", metricType, item.Processes, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "ProcessorQueueLength", metricType, item.ProcessorQueueLength, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "SystemCallsPerSec", metricType, item.SystemCallsPerSec, cgm.Tags{})
+		_ = c.addMetric(&metrics, "", "Threads", metricType, item.Threads, cgm.Tags{})
+	}
+
+	c.setStatus(metrics, nil)
+	return nil
+}

--- a/internal/builtins/collector/windows/wmi/wmi.go
+++ b/internal/builtins/collector/windows/wmi/wmi.go
@@ -195,6 +195,14 @@ func New() ([]collector.Collector, error) {
 			}
 			collectors = append(collectors, c)
 
+		case "system":
+			c, err := NewSystemCollector(path.Join(defaults.EtcPath, cfgBase))
+			if err != nil {
+				logError(name, err)
+				continue
+			}
+			collectors = append(collectors, c)
+
 		default:
 			l.Warn().
 				Str("name", name).

--- a/internal/check/bundle/broker_test.go
+++ b/internal/check/bundle/broker_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/circonus-labs/circonus-agent/internal/config/defaults"
 	"github.com/circonus-labs/go-apiclient"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -121,7 +122,7 @@ func Test_brokerSupportsCheckType(t *testing.T) {
 		{"nil details", args{checkType: "json", details: nil}, false},
 		{"unsupported type", args{checkType: "invalid", details: defaultDetails}, false},
 		{"supported type (json)", args{checkType: "json", details: defaultDetails}, true},
-		{"supported subtype (json:nad)", args{checkType: "json:nad", details: defaultDetails}, true},
+		{"supported subtype (" + defaults.CheckType + ")", args{checkType: defaults.CheckType, details: defaultDetails}, true},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -181,10 +182,10 @@ func TestBundle_selectBroker(t *testing.T) {
 		needTestServer bool
 	}{
 		{"invalid check type (empty)", defaultFields, args{checkType: "", brokerList: nil}, nil, true, false},
-		{"invalid broker list (nil)", defaultFields, args{checkType: "json:nad", brokerList: nil}, nil, true, false},
-		{"invalid broker list (empty)", defaultFields, args{checkType: "json:nad", brokerList: &[]apiclient.Broker{}}, nil, true, false},
-		{"no valid broker", defaultFields, args{checkType: "json:nad", brokerList: &noValidBrokers}, nil, true, false},
-		{"valid", defaultFields, args{checkType: "json:nad", brokerList: &noValidBrokers}, nil, false, true},
+		{"invalid broker list (nil)", defaultFields, args{checkType: defaults.CheckType, brokerList: nil}, nil, true, false},
+		{"invalid broker list (empty)", defaultFields, args{checkType: defaults.CheckType, brokerList: &[]apiclient.Broker{}}, nil, true, false},
+		{"no valid broker", defaultFields, args{checkType: defaults.CheckType, brokerList: &noValidBrokers}, nil, true, false},
+		{"valid", defaultFields, args{checkType: defaults.CheckType, brokerList: &noValidBrokers}, nil, false, true},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/check/bundle/bundle_test.go
+++ b/internal/check/bundle/bundle_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/circonus-labs/circonus-agent/internal/config"
+	"github.com/circonus-labs/circonus-agent/internal/config/defaults"
 	"github.com/circonus-labs/go-apiclient"
 	"github.com/gojuno/minimock/v3"
 	"github.com/rs/zerolog"
@@ -181,7 +182,7 @@ func TestFindCheck(t *testing.T) {
 			t.Fatal("expected found == 0")
 		}
 
-		if err.Error() != `no check bundles matched criteria ((active:1)(type:"json:nad")(target:"not_found"))` {
+		if err.Error() != `no check bundles matched criteria ((active:1)(type:"`+defaults.CheckType+`")(target:"not_found"))` {
 			t.Fatalf("unexpected error return (%s)", err)
 		}
 	}
@@ -199,7 +200,7 @@ func TestFindCheck(t *testing.T) {
 			t.Fatal("expected found == 2")
 		}
 
-		if err.Error() != `multiple check bundles (2) found matching criteria ((active:1)(type:"json:nad")(target:"multiple2")) created by (circonus-agent)` {
+		if err.Error() != `multiple check bundles (2) found matching criteria ((active:1)(type:"`+defaults.CheckType+`")(target:"multiple2")) created by (circonus-agent)` {
 			t.Fatalf("unexpected error return (%s)", err)
 		}
 	}
@@ -231,7 +232,7 @@ func TestFindCheck(t *testing.T) {
 			t.Fatal("expected found == 0")
 		}
 
-		if err.Error() != `multiple check bundles (2) found matching criteria ((active:1)(type:"json:nad")(target:"multiple0")), none created by (circonus-agent)` {
+		if err.Error() != `multiple check bundles (2) found matching criteria ((active:1)(type:"`+defaults.CheckType+`")(target:"multiple0")), none created by (circonus-agent)` {
 			t.Fatalf("unexpected error return (%s)", err)
 		}
 	}

--- a/internal/check/bundle/tags.go
+++ b/internal/check/bundle/tags.go
@@ -1,3 +1,8 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
 // +build !openbsd
 
 package bundle

--- a/internal/check/bundle/tags_openbsd.go
+++ b/internal/check/bundle/tags_openbsd.go
@@ -1,3 +1,8 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
 // +build openbsd
 
 package bundle

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,30 +105,37 @@ type StatsD struct {
 	Port     string      `json:"port" yaml:"port" toml:"port"`
 }
 
+// Thresholds defines triggers used to include metrics
+type Thresholds struct {
+	HighCPU    float32 `mapstructure:"high_cpu" json:"high_cpu" toml:"high_cpu" yaml:"high_cpu"`
+	HighMemory float32 `mapstructure:"high_memory" json:"high_memory" toml:"high_memory" yaml:"high_memory"`
+}
+
 // Config defines the running config structure
 type Config struct {
-	API              API        `json:"api" yaml:"api" toml:"api"`
+	StatsD           StatsD     `json:"statsd" yaml:"statsd" toml:"statsd"`
 	Check            Check      `json:"check" yaml:"check" toml:"check"`
+	API              API        `json:"api" yaml:"api" toml:"api"`
+	SSL              SSL        `json:"ssl" yaml:"ssl" toml:"ssl"`
+	Reverse          Reverse    `json:"reverse" yaml:"reverse" toml:"reverse"`
 	Collectors       []string   `json:"collectors" yaml:"collectors" toml:"collectors"`
-	Debug            bool       `json:"debug" yaml:"debug" toml:"debug"`
-	DebugCGM         bool       `mapstructure:"debug_cgm" json:"debug_cgm" yaml:"debug_cgm" toml:"debug_cgm"`
-	DebugAPI         bool       `mapstructure:"debug_api" json:"debug_api" yaml:"debug_api" toml:"debug_api"`
-	DebugDumpMetrics string     `mapstructure:"debug_dump_metrics" json:"debug_dump_metrics" yaml:"debug_dump_metrics" toml:"debug_dump_metrics"`
 	Listen           []string   `json:"listen" yaml:"listen" toml:"listen"`
 	ListenSocket     []string   `mapstructure:"listen_socket" json:"listen_socket" yaml:"listen_socket" toml:"listen_socket"`
-	Log              Log        `json:"log" yaml:"log" toml:"log"`
-	PluginDir        string     `mapstructure:"plugin_dir" json:"plugin_dir" yaml:"plugin_dir" toml:"plugin_dir"`
 	PluginList       []string   `mapstructure:"plugin_list" json:"plugin_list" yaml:"plugin_list" toml:"plugin_list"`
-	PluginTTLUnits   string     `mapstructure:"plugin_ttl_units" json:"plugin_ttl_units" yaml:"plugin_ttl_units" toml:"plugin_ttl_units"`
-	Reverse          Reverse    `json:"reverse" yaml:"reverse" toml:"reverse"`
+	Log              Log        `json:"log" yaml:"log" toml:"log"`
 	MultiAgent       MultiAgent `mapstructure:"multi_agent" json:"multi_agent" toml:"multi_agent" yaml:"multi_agent"`
-	SSL              SSL        `json:"ssl" yaml:"ssl" toml:"ssl"`
-	StatsD           StatsD     `json:"statsd" yaml:"statsd" toml:"statsd"`
+	DebugDumpMetrics string     `mapstructure:"debug_dump_metrics" json:"debug_dump_metrics" yaml:"debug_dump_metrics" toml:"debug_dump_metrics"`
+	PluginDir        string     `mapstructure:"plugin_dir" json:"plugin_dir" yaml:"plugin_dir" toml:"plugin_dir"`
+	PluginTTLUnits   string     `mapstructure:"plugin_ttl_units" json:"plugin_ttl_units" yaml:"plugin_ttl_units" toml:"plugin_ttl_units"`
 	HostProc         string     `mapstructure:"host_proc" json:"host_proc" toml:"host_proc" yaml:"host_proc"`
 	HostSys          string     `mapstructure:"host_sys" json:"host_sys" toml:"host_sys" yaml:"host_sys"`
 	HostEtc          string     `mapstructure:"host_etc" json:"host_etc" toml:"host_etc" yaml:"host_etc"`
 	HostVar          string     `mapstructure:"host_var" json:"host_var" toml:"host_var" yaml:"host_var"`
 	HostRun          string     `mapstructure:"host_run" json:"host_run" toml:"host_run" yaml:"host_run"`
+	Thresholds       Thresholds `mapstructure:"thresholds" json:"thresholds" toml:"thresholds" yaml:"thresholds"`
+	Debug            bool       `json:"debug" yaml:"debug" toml:"debug"`
+	DebugCGM         bool       `mapstructure:"debug_cgm" json:"debug_cgm" yaml:"debug_cgm" toml:"debug_cgm"`
+	DebugAPI         bool       `mapstructure:"debug_api" json:"debug_api" yaml:"debug_api" toml:"debug_api"`
 }
 
 //
@@ -160,6 +167,12 @@ const (
 	// it should contain a directory name where the user running circonus-agentd has write
 	// permissions. metrics will be dumped for each _successful_ request.
 	KeyDebugDumpMetrics = "debug_dump_metrics"
+
+	// Process metrics will be included if EITHER cpu or mem utilization percentages are above these thresholds
+	// KeyCPUThreshold high cpu utilization percentage to include process metrics
+	KeyCPUThreshold = "thresholds.high_cpu"
+	// KeyMemThreshold high memory utilization percentage to include process metrics
+	KeyMemThreshold = "thresholds.high_memory"
 
 	// KeyListen primary address and port to listen on
 	KeyListen = "listen"

--- a/internal/config/cosi_test.go
+++ b/internal/config/cosi_test.go
@@ -95,7 +95,7 @@ func TestLoadCosiV2Config(t *testing.T) {
 		shouldFail  bool
 		expectedErr string
 	}{
-		{"invalid (missing)", filepath.Join("testdata", "cosi_missing"), true, "unable to load cosi config: no config found matching (testdata/cosi_missing.json|.toml|.yaml)"},
+		{"invalid (missing)", filepath.Join("testdata", "cosi_missing"), true, "unable to load cosi config: no config found matching (testdata/cosi_missing.json|.toml|.yaml): file does not exist"},
 		{"invalid (bad)", filepath.Join("testdata", "cosi_bad"), true, "unable to load cosi config: parsing configuration file (testdata/cosi_bad.json): invalid character '#' looking for beginning of value"},
 		{"invalid (missing key)", filepath.Join("testdata", "cosiv2_invalid_key"), true, "missing API key, invalid cosi config (testdata/cosiv2_invalid_key)"},
 		{"invalid (missing app)", filepath.Join("testdata", "cosiv2_invalid_app"), true, "missing API app, invalid cosi config (testdata/cosiv2_invalid_app)"},

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -129,6 +129,11 @@ const (
 	ClusterEnableBuiltins = false
 	// Cluster mode represent statsd gauges as histogram samples, so that _one_ sample will be collected for each node
 	ClusterStatsdHistogramGauges = false
+
+	// Utilization thresholds for memory and cpu to trigger sending process metric (if a given process is higher for EITHER)
+	// -1 disables the feature
+	CPUThreshold = float32(-1)
+	MemThreshold = float32(-1)
 )
 
 var (
@@ -195,6 +200,8 @@ var (
 
 	// StatsdConf returns the default statsd config file
 	StatsdConf = "" // (e.g. /opt/circonus/agent/etc/statsd.json)
+
+	CheckType = ""
 )
 
 func init() {
@@ -229,6 +236,8 @@ func init() {
 	}
 	CheckTitle = CheckTarget + " /agent"
 
+	CheckType = "json:" + release.NAME + ":" + runtime.GOOS
+
 	switch runtime.GOOS {
 	case "linux":
 		Collectors = []string{
@@ -253,6 +262,7 @@ func init() {
 			"wmi/processor",
 			"wmi/tcp", // ipv4 and ipv6
 			"wmi/udp", // ipv4 and ipv6
+			"wmi/system",
 		}
 	default:
 		Collectors = []string{

--- a/internal/config/load_config.go
+++ b/internal/config/load_config.go
@@ -17,6 +17,15 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+type FileNotFoundErr struct {
+	Name    string
+	ExtList []string
+}
+
+func (e *FileNotFoundErr) Error() string {
+	return fmt.Sprintf("no config found matching (%s%s)", e.Name, strings.Join(e.ExtList, "|"))
+}
+
 // LoadConfigFile will attempt to load json|toml|yaml configuration files.
 // `base` is the full path and base name of the configuration file to load.
 // `target` is an interface in to which the data will be loaded. Checks for
@@ -60,7 +69,7 @@ func LoadConfigFile(base string, target interface{}) error {
 	}
 
 	if !loaded {
-		return errors.Errorf("no config found matching (%s%s)", base, strings.Join(extensions, "|"))
+		return errors.Wrapf(os.ErrNotExist, "no config found matching (%s%s)", base, strings.Join(extensions, "|"))
 	}
 
 	return nil

--- a/internal/server/agent_host_stats.go
+++ b/internal/server/agent_host_stats.go
@@ -1,0 +1,129 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build !openbsd
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/circonus-labs/circonus-agent/internal/config"
+	"github.com/circonus-labs/circonus-agent/internal/tags"
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/process"
+	"github.com/spf13/viper"
+)
+
+// agentHostStats produces the internal agent host metrics
+func (s *Server) agentHostStats(metrics cgm.Metrics, mtags []string) {
+
+	// uptime
+	if ut, err := host.Uptime(); err != nil {
+		s.logger.Error().Err(err).Msg("host uptime")
+	} else {
+		var ctag []string
+		ctag = append(ctag, mtags...)
+		ctag = append(ctag, "units:seconds")
+		metrics[tags.MetricNameWithStreamTags("agent_host_uptime", tags.FromList(ctag))] = cgm.Metric{Value: ut, Type: "L"}
+	}
+
+	// cpus
+	if pcpu, err := cpu.Counts(false); err != nil {
+		s.logger.Error().Err(err).Msg("physical cores")
+	} else {
+		var ctag []string
+		ctag = append(ctag, mtags...)
+		ctag = append(ctag, "type:physical")
+		metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: pcpu, Type: "L"}
+	}
+	if lcpu, err := cpu.Counts(true); err != nil {
+		s.logger.Error().Err(err).Msg("logical cores")
+	} else {
+		var ctag []string
+		ctag = append(ctag, mtags...)
+		ctag = append(ctag, "type:logical")
+		metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: lcpu, Type: "L"}
+	}
+
+	// memory
+	ms, err := mem.VirtualMemory()
+	if err != nil {
+		s.logger.Error().Err(err).Msg("memory")
+	} else {
+		var ctag []string
+		ctag = append(ctag, mtags...)
+		ctag = append(ctag, "units:bytes")
+		metrics[tags.MetricNameWithStreamTags("agent_host_memory", tags.FromList(ctag))] = cgm.Metric{Value: ms.Total, Type: "L"}
+		// metrics[tags.MetricNameWithStreamTags("agent_host_memory_used", tags.FromList(ctag))] = cgm.Metric{Value: ms.Used, Type: "L"}
+	}
+
+	// processes
+	memLimit := float32(viper.GetFloat64(config.KeyMemThreshold))
+	cpuLimit := float64(viper.GetFloat64(config.KeyCPUThreshold))
+
+	// only do this if someone actually turns it on the default, -1=disabled
+	if memLimit < 0 && cpuLimit < 0 {
+		return
+	}
+
+	pp, err := process.Processes()
+	if err != nil {
+		s.logger.Error().Err(err).Msg("process list, skipping")
+		return
+	}
+
+	var merr, cerr, nerr error
+	var mp float32
+	var cp float64
+	var pname string
+	for _, p := range pp {
+		if running, _ := p.IsRunning(); !running {
+			continue
+		}
+
+		if memLimit >= 0 {
+			mp, merr = p.MemoryPercent()
+		}
+		if cpuLimit >= 0 {
+			cp, cerr = p.CPUPercent()
+		}
+		pname, nerr = p.Name()
+
+		if merr != nil && cerr != nil {
+			continue
+		}
+
+		var baseTags []string
+		baseTags = append(baseTags, mtags...)
+		baseTags = append(baseTags, []string{fmt.Sprintf("pid:%d", p.Pid), "units:percent"}...)
+		if nerr == nil {
+			baseTags = append(baseTags, "name:"+pname)
+		}
+
+		metricName := "process_threshold"
+
+		if merr == nil && memLimit >= 0 {
+			if mp >= memLimit {
+				var memTags []string
+				memTags = append(memTags, baseTags...)
+				memTags = append(memTags, "resource:memory")
+				metrics[tags.MetricNameWithStreamTags(metricName, tags.FromList(memTags))] = cgm.Metric{Value: mp, Type: "n"}
+			}
+		}
+
+		if cerr == nil && cpuLimit >= 0 {
+			if cp >= cpuLimit {
+				var cpuTags []string
+				cpuTags = append(cpuTags, baseTags...)
+				cpuTags = append(cpuTags, "resource:cpu")
+				metrics[tags.MetricNameWithStreamTags(metricName, tags.FromList(cpuTags))] = cgm.Metric{Value: cp, Type: "n"}
+			}
+		}
+	}
+}

--- a/internal/server/agent_host_stats.go
+++ b/internal/server/agent_host_stats.go
@@ -9,6 +9,7 @@ package server
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/circonus-labs/circonus-agent/internal/config"
 	"github.com/circonus-labs/circonus-agent/internal/tags"
@@ -34,95 +35,113 @@ func (s *Server) agentHostStats(metrics cgm.Metrics, mtags []string) {
 	}
 
 	// cpus
-	if pcpu, err := cpu.Counts(false); err != nil {
-		s.logger.Error().Err(err).Msg("physical cores")
-	} else {
-		var ctag []string
-		ctag = append(ctag, mtags...)
-		ctag = append(ctag, "type:physical")
-		metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: pcpu, Type: "L"}
+	{
+		if pcpu, err := cpu.Counts(false); err != nil {
+			s.logger.Error().Err(err).Msg("physical cores")
+		} else {
+			var ctag []string
+			ctag = append(ctag, mtags...)
+			ctag = append(ctag, "type:physical")
+			metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: pcpu, Type: "L"}
+		}
+		if lcpu, err := cpu.Counts(true); err != nil {
+			s.logger.Error().Err(err).Msg("logical cores")
+		} else {
+			var ctag []string
+			ctag = append(ctag, mtags...)
+			ctag = append(ctag, "type:logical")
+			metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: lcpu, Type: "L"}
+		}
 	}
-	if lcpu, err := cpu.Counts(true); err != nil {
-		s.logger.Error().Err(err).Msg("logical cores")
-	} else {
-		var ctag []string
-		ctag = append(ctag, mtags...)
-		ctag = append(ctag, "type:logical")
-		metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: lcpu, Type: "L"}
+	// memory
+	{
+		if ms, err := mem.VirtualMemory(); err != nil {
+			s.logger.Error().Err(err).Msg("memory")
+		} else {
+			var ctag []string
+			ctag = append(ctag, mtags...)
+			ctag = append(ctag, "units:bytes")
+			metrics[tags.MetricNameWithStreamTags("agent_host_memory", tags.FromList(ctag))] = cgm.Metric{Value: ms.Total, Type: "L"}
+			// metrics[tags.MetricNameWithStreamTags("agent_host_memory_used", tags.FromList(ctag))] = cgm.Metric{Value: ms.Used, Type: "L"}
+		}
 	}
 
-	// memory
-	ms, err := mem.VirtualMemory()
-	if err != nil {
-		s.logger.Error().Err(err).Msg("memory")
-	} else {
-		var ctag []string
-		ctag = append(ctag, mtags...)
-		ctag = append(ctag, "units:bytes")
-		metrics[tags.MetricNameWithStreamTags("agent_host_memory", tags.FromList(ctag))] = cgm.Metric{Value: ms.Total, Type: "L"}
-		// metrics[tags.MetricNameWithStreamTags("agent_host_memory_used", tags.FromList(ctag))] = cgm.Metric{Value: ms.Used, Type: "L"}
+	// agent process
+	{
+		pid := os.Getpid()
+		if p, err := process.NewProcess(int32(pid)); err != nil {
+			s.logger.Error().Err(err).Msg("agent process")
+		} else {
+			if threads, err := p.NumThreads(); err != nil {
+				s.logger.Error().Err(err).Msg("agent process threads")
+			} else {
+				metrics[tags.MetricNameWithStreamTags("agent_threads", tags.FromList(mtags))] = cgm.Metric{Value: threads, Type: "L"}
+			}
+		}
 	}
 
 	// processes
-	memLimit := float32(viper.GetFloat64(config.KeyMemThreshold))
-	cpuLimit := float64(viper.GetFloat64(config.KeyCPUThreshold))
+	{
+		memLimit := float32(viper.GetFloat64(config.KeyMemThreshold))
+		cpuLimit := float64(viper.GetFloat64(config.KeyCPUThreshold))
 
-	// only do this if someone actually turns it on the default, -1=disabled
-	if memLimit < 0 && cpuLimit < 0 {
-		return
-	}
-
-	pp, err := process.Processes()
-	if err != nil {
-		s.logger.Error().Err(err).Msg("process list, skipping")
-		return
-	}
-
-	var merr, cerr, nerr error
-	var mp float32
-	var cp float64
-	var pname string
-	for _, p := range pp {
-		if running, _ := p.IsRunning(); !running {
-			continue
+		// only do this if someone actually turns it on the default, -1=disabled
+		if memLimit < 0 && cpuLimit < 0 {
+			return
 		}
 
-		if memLimit >= 0 {
-			mp, merr = p.MemoryPercent()
-		}
-		if cpuLimit >= 0 {
-			cp, cerr = p.CPUPercent()
-		}
-		pname, nerr = p.Name()
-
-		if merr != nil && cerr != nil {
-			continue
+		pp, err := process.Processes()
+		if err != nil {
+			s.logger.Error().Err(err).Msg("process list, skipping")
+			return
 		}
 
-		var baseTags []string
-		baseTags = append(baseTags, mtags...)
-		baseTags = append(baseTags, []string{fmt.Sprintf("pid:%d", p.Pid), "units:percent"}...)
-		if nerr == nil {
-			baseTags = append(baseTags, "name:"+pname)
-		}
-
-		metricName := "process_threshold"
-
-		if merr == nil && memLimit >= 0 {
-			if mp >= memLimit {
-				var memTags []string
-				memTags = append(memTags, baseTags...)
-				memTags = append(memTags, "resource:memory")
-				metrics[tags.MetricNameWithStreamTags(metricName, tags.FromList(memTags))] = cgm.Metric{Value: mp, Type: "n"}
+		var merr, cerr, nerr error
+		var mp float32
+		var cp float64
+		var pname string
+		for _, p := range pp {
+			if running, _ := p.IsRunning(); !running {
+				continue
 			}
-		}
 
-		if cerr == nil && cpuLimit >= 0 {
-			if cp >= cpuLimit {
-				var cpuTags []string
-				cpuTags = append(cpuTags, baseTags...)
-				cpuTags = append(cpuTags, "resource:cpu")
-				metrics[tags.MetricNameWithStreamTags(metricName, tags.FromList(cpuTags))] = cgm.Metric{Value: cp, Type: "n"}
+			if memLimit >= 0 {
+				mp, merr = p.MemoryPercent()
+			}
+			if cpuLimit >= 0 {
+				cp, cerr = p.CPUPercent()
+			}
+			pname, nerr = p.Name()
+
+			if merr != nil && cerr != nil {
+				continue
+			}
+
+			var baseTags []string
+			baseTags = append(baseTags, mtags...)
+			baseTags = append(baseTags, []string{fmt.Sprintf("pid:%d", p.Pid), "units:percent"}...)
+			if nerr == nil {
+				baseTags = append(baseTags, "name:"+pname)
+			}
+
+			metricName := "process_threshold"
+
+			if merr == nil && memLimit >= 0 {
+				if mp >= memLimit {
+					var memTags []string
+					memTags = append(memTags, baseTags...)
+					memTags = append(memTags, "resource:memory")
+					metrics[tags.MetricNameWithStreamTags(metricName, tags.FromList(memTags))] = cgm.Metric{Value: mp, Type: "n"}
+				}
+			}
+
+			if cerr == nil && cpuLimit >= 0 {
+				if cp >= cpuLimit {
+					var cpuTags []string
+					cpuTags = append(cpuTags, baseTags...)
+					cpuTags = append(cpuTags, "resource:cpu")
+					metrics[tags.MetricNameWithStreamTags(metricName, tags.FromList(cpuTags))] = cgm.Metric{Value: cp, Type: "n"}
+				}
 			}
 		}
 	}

--- a/internal/server/agent_host_stats_openbsd.go
+++ b/internal/server/agent_host_stats_openbsd.go
@@ -1,0 +1,54 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build openbsd
+
+package server
+
+import (
+	"github.com/circonus-labs/circonus-agent/internal/tags"
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/mem"
+)
+
+// agentHostStats produces the internal agent host metrics
+func (s *Server) agentHostStats(metrics cgm.Metrics, mtags []string) {
+	///
+	// NOTE: host/process packages have an error on openbsd at the moment
+	//
+	// if ut, err := host.Uptime(); err != nil {
+	// 	metrics[tags.MetricNameWithStreamTags("circonus_agent_uptime", tags.FromList(mtags))] = cgm.Metric{Value: ut, Type: "L"}
+	// }
+
+	if pcpu, err := cpu.Counts(false); err != nil {
+		s.logger.Error().Err(err).Msg("cpu physical")
+	} else {
+		var ctag []string
+		ctag = append(ctag, mtags...)
+		ctag = append(ctag, "type:physical")
+		metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: pcpu, Type: "L"}
+	}
+	if lcpu, err := cpu.Counts(true); err != nil {
+		s.logger.Error().Err(err).Msg("cpu logical")
+	} else {
+		var ctag []string
+		ctag = append(ctag, mtags...)
+		ctag = append(ctag, "type:logical")
+		metrics[tags.MetricNameWithStreamTags("agent_host_cores", tags.FromList(ctag))] = cgm.Metric{Value: lcpu, Type: "L"}
+	}
+
+	// memory
+	ms, err := mem.VirtualMemory()
+	if err != nil {
+		s.logger.Error().Err(err).Msg("memory")
+	} else {
+		var ctag []string
+		ctag = append(ctag, mtags...)
+		ctag = append(ctag, "units:bytes")
+		metrics[tags.MetricNameWithStreamTags("agent_host_memory", tags.FromList(ctag))] = cgm.Metric{Value: ms.Total, Type: "L"}
+		// metrics[tags.MetricNameWithStreamTags("agent_host_memory_used", tags.FromList(ctag))] = cgm.Metric{Value: ms.Used, Type: "L"}
+	}
+}

--- a/internal/server/agent_mem_stats.go
+++ b/internal/server/agent_mem_stats.go
@@ -1,0 +1,25 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build !windows,!illumos,!solaris
+
+package server
+
+import (
+	"syscall"
+
+	"github.com/circonus-labs/circonus-agent/internal/tags"
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+)
+
+// agentMemoryStats produces the internal agent metrics
+func (s *Server) agentMemoryStats(metrics cgm.Metrics, mtags []string) {
+	var mem syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &mem); err == nil {
+		metrics[tags.MetricNameWithStreamTags("agent_max_rss", tags.FromList(mtags))] = cgm.Metric{Value: uint64(mem.Maxrss * 1024), Type: "L"} // maximum resident set size used (in kilobytes)
+	} else {
+		s.logger.Warn().Err(err).Msg("collecting rss from system")
+	}
+}

--- a/internal/server/agent_mem_stats_solaris.go
+++ b/internal/server/agent_mem_stats_solaris.go
@@ -1,0 +1,22 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build solaris illumos
+
+package server
+
+import (
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+)
+
+// agentMemoryStats produces the internal agent metrics
+func (s *Server) agentMemoryStats(metrics cgm.Metrics, mtags []string) {
+	// var mem syscall.Rusage
+	// if err := syscall.Getrusage(syscall.RUSAGE_SELF, &mem); err == nil {
+	// 	metrics[tags.MetricNameWithStreamTags("agent_max_rss", tags.FromList(ctags))] = cgm.Metric{Value: uint64(mem.Maxrss * 1024), Type: "L"} // maximum resident set size used (in kilobytes)
+	// } else {
+	// 	s.logger.Warn().Err(err).Msg("collecting rss from system")
+	// }
+}

--- a/internal/server/agent_mem_stats_windows.go
+++ b/internal/server/agent_mem_stats_windows.go
@@ -1,0 +1,22 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build windows
+
+package server
+
+import (
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+)
+
+// agentMemoryStats produces the internal agent metrics
+func (s *Server) agentMemoryStats(metrics cgm.Metrics, mtags []string) {
+	// var mem syscall.Rusage
+	// if err := syscall.Getrusage(syscall.RUSAGE_SELF, &mem); err == nil {
+	// 	metrics[tags.MetricNameWithStreamTags("agent_max_rss", tags.FromList(ctags))] = cgm.Metric{Value: uint64(mem.Maxrss * 1024), Type: "L"} // maximum resident set size used (in kilobytes)
+	// } else {
+	// 	s.logger.Warn().Err(err).Msg("collecting rss from system")
+	// }
+}

--- a/internal/server/agent_stats.go
+++ b/internal/server/agent_stats.go
@@ -1,0 +1,46 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package server
+
+import (
+	"runtime"
+	"runtime/debug"
+
+	"github.com/circonus-labs/circonus-agent/internal/tags"
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+)
+
+// agentStats produces the internal agent metrics
+func (s *Server) agentStats(metrics cgm.Metrics, mtags []string) {
+	s.agentHostStats(metrics, mtags)
+
+	debug.FreeOSMemory()
+
+	// memory utilization metrics
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	metrics[tags.MetricNameWithStreamTags("agent_mem_frag", tags.FromList(mtags))] = cgm.Metric{Value: float64(ms.Sys-ms.HeapReleased) / float64(ms.HeapInuse), Type: "n"}
+	metrics[tags.MetricNameWithStreamTags("agent_numgc", tags.FromList(mtags))] = cgm.Metric{Value: ms.NumGC, Type: "L"}
+	metrics[tags.MetricNameWithStreamTags("agent_heap_objs", tags.FromList(mtags))] = cgm.Metric{Value: ms.HeapObjects, Type: "L"}
+	metrics[tags.MetricNameWithStreamTags("agent_live_objs", tags.FromList(mtags))] = cgm.Metric{Value: ms.Mallocs - ms.Frees, Type: "L"}
+
+	{
+		var ctags []string
+		ctags = append(ctags, mtags...)
+		ctags = append(ctags, "units:bytes")
+
+		metrics[tags.MetricNameWithStreamTags("agent_heap_alloc", tags.FromList(ctags))] = cgm.Metric{Value: ms.HeapAlloc, Type: "L"}
+		metrics[tags.MetricNameWithStreamTags("agent_heap_inuse", tags.FromList(ctags))] = cgm.Metric{Value: ms.HeapInuse, Type: "L"}
+		metrics[tags.MetricNameWithStreamTags("agent_heap_idle", tags.FromList(ctags))] = cgm.Metric{Value: ms.HeapIdle, Type: "L"}
+		metrics[tags.MetricNameWithStreamTags("agent_heap_released", tags.FromList(ctags))] = cgm.Metric{Value: ms.HeapReleased, Type: "L"}
+		metrics[tags.MetricNameWithStreamTags("agent_stack_sys", tags.FromList(ctags))] = cgm.Metric{Value: ms.StackSys, Type: "L"}
+		metrics[tags.MetricNameWithStreamTags("agent_other_sys", tags.FromList(ctags))] = cgm.Metric{Value: ms.OtherSys, Type: "L"}
+
+		s.agentMemoryStats(metrics, ctags)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -108,9 +108,11 @@ func (s *Server) run(w http.ResponseWriter, r *http.Request) {
 
 // GetMetrics collects metrics from the various conduits and returns them for disposition
 func (s *Server) GetMetrics(conduits []string, id string) cgm.Metrics {
+	includeAgentMetrics := false
 	// default to all conduits if list is empty
 	if len(conduits) == 0 {
 		conduits = []string{conduitBuiltin, conduitPlugin, conduitReceiver, conduitStatsd, conduitPrometheus}
+		includeAgentMetrics = true
 	}
 
 	collectStart := time.Now()
@@ -221,7 +223,7 @@ func (s *Server) GetMetrics(conduits []string, id string) cgm.Metrics {
 
 	cdur := time.Since(collectStart)
 
-	{
+	if includeAgentMetrics {
 		mtags := tags.GetBaseTags()
 		mtags = append(mtags, []string{"collector:agent", "__rollup:false"}...)
 		if viper.GetBool(config.KeyClusterEnabled) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -51,6 +51,8 @@ func TestRun(t *testing.T) {
 	testDir := path.Join(dir, "testdata")
 
 	viper.Reset()
+	viper.Set(config.KeyCPUThreshold, -1)
+	viper.Set(config.KeyMemThreshold, -1)
 	viper.Set(config.KeyPluginDir, testDir)
 	viper.Set(config.KeyListen, ":2609")
 	b, berr := builtins.New(context.Background())


### PR DESCRIPTION
Note: For automatic host dashboards a new check type is being used. This makes this update **not** backwards compatible. It will create a new check of the correct type.

* add: new check types for automatic dashboard
* add: internal agent metrics `agent_*` for new dashboard
* add: host based check tags for new dashboard
* add: check bundle tag updater
* add: wmi/system builtin collector
* add: settings for cpu and memory utilization thresholds for `process_threshold` metrics
* fix: various tests for new features
* upd: silently ignore prom config missing for builtin, just disable quietly
* upd: config loader, return `os.ErrNotExist` wrapped for `errors.Is`