### PR TITLE
Add SmartOS global zone toolset paths

### DIFF
--- a/service/circonus-agent.xml-smf
+++ b/service/circonus-agent.xml-smf
@@ -17,6 +17,7 @@
       <method_credential user='nobody' group='nobody'/>
       <method_environment>
         <envvar name='HOME' value='/opt/circonus/agent'/>
+        <envvar name='PATH' value='/usr/sbin:/usr/bin:/opt/tools/sbin:/opt/tools/bin'/>
       </method_environment>
     </method_context>
     <exec_method name='start' type='method' exec='/opt/circonus/agent/sbin/circonus-agentd' timeout_seconds='60'/>


### PR DESCRIPTION
Allows the agent to run in a global zone, using the
[GZ pkgsrc tools](https://pkgsrc.joyent.com/install-on-illumos/).

Copy the SMF manifest to `/opt/custom/smf/circonus-agent.xml` to ensure
the service is available on boot.