### PR TITLE
Adding generate-config functionality

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,21 @@ in JSON format.`,
 			return
 		}
 
+		//
+		// generate tmp config file in etc/ and exit
+		//
+		if viper.GetString(config.KeyGenerateConfig) != "" {
+			f, err := os.Create(fmt.Sprintf("%s/circonus-agent.%s.tmp", defaults.EtcPath, viper.GetString(config.KeyGenerateConfig)))
+			if err != nil {
+				log.Fatal().Err(err).Msg("generate-config")
+			}
+			defer f.Close()
+			if err := config.GenerateConfig(f); err != nil {
+				log.Fatal().Err(err).Msg("generate-config")
+			}
+			return
+		}
+
 		log.Info().
 			Int("pid", os.Getpid()).
 			Str("name", release.NAME).
@@ -1278,6 +1293,19 @@ func init() {
 			key         = config.KeyShowConfig
 			longOpt     = "show-config"
 			description = "Show config (json|toml|yaml) and exit"
+		)
+
+		RootCmd.Flags().String(longOpt, "", description)
+		if err := viper.BindPFlag(key, RootCmd.Flags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+	}
+
+	{
+		const (
+			key         = config.KeyGenerateConfig
+			longOpt     = "generate-config"
+			description = "Generate config file (json|toml|yaml) and exit"
 		)
 
 		RootCmd.Flags().String(longOpt, "", description)

--- a/etc/README.md
+++ b/etc/README.md
@@ -6,9 +6,11 @@ The `etc` directory is used for the main configuration of the Circonus agent, as
 
 File name: `circonus-agent.(json|toml|yaml)`
 
-An example configuration, with default values, can be retrieved using the `--show-config=(json|toml|yaml)`.
+An example configuration, with default values, can be retrieved using the `--show-config=(json|toml|yaml)` or `--generate-config=(json|toml|yaml)`.
 
 ## Configuration file quick start
+
+### Using show-config
 
 Run one of the following (from the base directory where the agent was installed) and edit the resulting configuration file:
 
@@ -25,6 +27,26 @@ or, on Windows:
 sbin\circonus-agentd.exe --show-config=json > etc\circonus-agent.json.tmp
 sbin\circonus-agentd.exe --show-config=toml > etc\circonus-agent.toml.tmp
 sbin\circonus-agentd.exe --show-config=yaml > etc\circonus-agent.yaml.tmp
+```
+
+Edit the resulting file to customize configuration settings. When done, rename file to remove the `.tmp` extension. (e.g. `mv etc/circonus-agent.json.tmp` `etc/circonus-agent.json`)
+
+### Using generate-config
+
+Run one of the following (from the base directory where the agent was installed) and edit the resulting configuration file:
+
+```
+sbin/circonus-agentd --generate-config=json
+sbin/circonus-agentd --generate-config=toml
+sbin/circonus-agentd --generate-config=yaml
+```
+
+or, on Windows:
+
+```
+sbin\circonus-agentd.exe --generate-config=json
+sbin\circonus-agentd.exe --generate-config=toml
+sbin\circonus-agentd.exe --generate-config=yaml
 ```
 
 Edit the resulting file to customize configuration settings. When done, rename file to remove the `.tmp` extension. (e.g. `mv etc/circonus-agent.json.tmp` `etc/circonus-agent.json`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,9 @@ const (
 	// KeyShowConfig - show configuration and exit
 	KeyShowConfig = "show-config"
 
+	// KeyGenerateConfig - generate temporary config file in given format and exit
+	KeyGenerateConfig = "generate-config"
+
 	// KeyShowVersion - show version information and exit
 	KeyShowVersion = "version"
 
@@ -432,6 +435,38 @@ func ShowConfig(w io.Writer) error {
 	format := viper.GetString(KeyShowConfig)
 
 	// log.Debug().Str("format", format).Msg("show-config")
+
+	switch format {
+	case "json":
+		data, err = json.MarshalIndent(cfg, " ", "  ")
+	case "yaml":
+		data, err = yaml.Marshal(cfg)
+	case "toml":
+		data, err = toml.Marshal(*cfg)
+	default:
+		return errors.Errorf("unknown config format '%s'", format)
+	}
+
+	if err != nil {
+		return errors.Wrapf(err, "formatting config (%s)", format)
+	}
+
+	fmt.Fprintln(w, string(data))
+	return nil
+}
+
+// GenerateConfig creates a temp config file in etc/
+func GenerateConfig(w io.Writer) error {
+	var cfg *Config
+	var err error
+	var data []byte
+
+	cfg, err = getConfig()
+	if err != nil {
+		return err
+	}
+
+	format := viper.GetString(KeyGenerateConfig)
 
 	switch format {
 	case "json":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,6 +68,38 @@ func TestShowConfig(t *testing.T) {
 	}
 }
 
+func TestGenerateConfig(t *testing.T) {
+	t.Log("Testing ShowConfig")
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	t.Log("YAML")
+	{
+		viper.Set(KeyGenerateConfig, "yaml")
+		err := GenerateConfig(ioutil.Discard)
+		if err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+	}
+
+	t.Log("TOML")
+	{
+		viper.Set(KeyGenerateConfig, "toml")
+		err := GenerateConfig(ioutil.Discard)
+		if err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+	}
+
+	t.Log("JSON")
+	{
+		viper.Set(KeyGenerateConfig, "json")
+		err := GenerateConfig(ioutil.Discard)
+		if err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+	}
+}
+
 func TestGetConfig(t *testing.T) {
 	t.Log("Testing getConfig")
 	zerolog.SetGlobalLevel(zerolog.Disabled)


### PR DESCRIPTION
generate-config allows users to simply issue `--generate-config=(json|toml|yaml)` and have the config file created for them under etc/ for their subsequent editing and use with the binary.