### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v2.2.0
+
+* new: statsd counters and sets represented as histograms (like broker)
+* upd: add `statsd_type` tag to counters, gauges, timings, and sets
+* upd: allow independent control of cgm debug (for statsd group) without having to turn on full debug logging
+* upd: support icmp6 intype135 (in neighbor solicits)
+* upd: cgm v3.3.0
+
 # v2.1.0
 
 * upd: statsd - change spaces to `_` in metric names (e.g. `foo bar` -> `foo_bar`) CIRC-6087

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4
-	github.com/circonus-labs/circonus-gometrics/v3 v3.2.2
+	github.com/circonus-labs/circonus-gometrics/v3 v3.3.0
 	github.com/circonus-labs/circonusllhist v0.1.4
 	github.com/circonus-labs/go-apiclient v0.7.10
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics/v3 v3.2.2 h1:7jZwhvIEt5vMKUlARs4fQz8PxHh8yUP1snn/5l+BBDA=
 github.com/circonus-labs/circonus-gometrics/v3 v3.2.2/go.mod h1:hbHb81YGFfRAgDZHE8J5kws/aDP1D40tkaTnhVfnqSw=
+github.com/circonus-labs/circonus-gometrics/v3 v3.3.0 h1:7jglWWxtmeRBHnxfDFJi4NVgeEgqgjg2YAG2I7KfM54=
+github.com/circonus-labs/circonus-gometrics/v3 v3.3.0/go.mod h1:hbHb81YGFfRAgDZHE8J5kws/aDP1D40tkaTnhVfnqSw=
 github.com/circonus-labs/circonusllhist v0.1.4 h1:G5qJPuD16akpIXMUR7KcfBvrQOVm95+qyqUm+SEAZks=
 github.com/circonus-labs/circonusllhist v0.1.4/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/circonus-labs/go-apiclient v0.7.6 h1:Pr69I76ReDKRKe/yb9o0lKphRQ/a6Jr8XLh7M4GZrPY=

--- a/internal/builtins/collector/linux/procfs/net_proto.go
+++ b/internal/builtins/collector/linux/procfs/net_proto.go
@@ -458,7 +458,7 @@ func (c *NetProto) emitICMPMetric(proto string, metrics *cgm.Metrics, name strin
 		// no units
 	case "InRouterAdvertisements":
 		// no units
-	case "InNeighborSolicits":
+	case "InNeighborSolicits", "InType135":
 		// no units
 	case "InNeighborAdvertisements":
 		// no units


### PR DESCRIPTION
* new: statsd counters and sets represented as histograms (like broker)
* upd: add `statsd_type` tag to counters, gauges, timings, and sets
* upd: allow independent control of cgm debug (for statsd group) without having to turn on full debug logging
* upd: support icmp6 intype135 (in neighbor solicits)
* upd: cgm v3.3.0
