### PR TITLE
v2.6.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.42
+          version: v1.52
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters-settings:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - exportloopref
     - gocritic
@@ -48,17 +47,18 @@ linters:
     - predeclared
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unparam
     - unused
-    - varcheck
     - unconvert
     - wrapcheck
   disable:
     - scopelint # deprecated, replaced by 
     - golint # deprecated, replaced by revive
     - gci
+    - deadcode # deprecated, replaced by unused
+    - varcheck # deprecated, replaced by unused
+    - structcheck # deprecated, replaced by unused
   disable-all: false
   presets:
     - bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# v2.6.0
+
+* fix(receiver): add SerializeB64 handling for histograms to the `/write` endpoint
+* feat: `/options` endpoint to dynamically control log_level (e.g. turn debug on/off while running)
+* feat(statsd): explicit metric parsing debug option
+* fix: don't swallow sigpipe
+* fix(lint): unsed args (generic, linux, & windows)
+* chore: golangci-lint v1.52
+* fix(lint): exports annotated with json tag
+* fix(lint): redundant if-return
+* fix(lint): deprecated linters
+* fix: installer to correctly use `.` and `_` for rpm and deb urls
+* build(deps): bump github.com/rs/zerolog from 1.26.1 to 1.28.0
+* build(deps): bump github.com/circonus-labs/go-apiclient from 0.7.17 to 0.7.18
+* upd: clean build dir on start, always clone repo
+* add: trigger on after up to check Go version
+* add: generic Go version checker script
+* build(deps): bump golangci/golangci-lint-action from 3.1.0 to 3.2.0
+
 # v2.5.0
 
 * fix: prevent `/usr/lib/.build-id` links from being created

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1425,7 +1425,7 @@ func init() {
 }
 
 // initLogging initializes zerolog.
-func initLogging(cmd *cobra.Command, args []string) error {
+func initLogging(_ *cobra.Command, args []string) error {
 	//
 	// Enable formatted output
 	//

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1425,7 +1425,7 @@ func init() {
 }
 
 // initLogging initializes zerolog.
-func initLogging(_ *cobra.Command, args []string) error {
+func initLogging(_ *cobra.Command, _ []string) error {
 	//
 	// Enable formatted output
 	//

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/maier/go-appstats v0.2.0
+	github.com/openhistogram/circonusllhist v0.3.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.37.0

--- a/internal/agent/sighndlr_bsdsol.go
+++ b/internal/agent/sighndlr_bsdsol.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (a *Agent) signalNotifySetup() {
-	signal.Notify(a.signalCh, os.Interrupt, unix.SIGTERM, unix.SIGHUP, unix.SIGPIPE, unix.SIGINFO)
+	signal.Notify(a.signalCh, os.Interrupt, unix.SIGTERM, unix.SIGHUP, unix.SIGINFO)
 }
 
 // handleSignals runs the signal handler thread.
@@ -39,7 +39,7 @@ func (a *Agent) handleSignals() error {
 			switch sig {
 			case os.Interrupt, unix.SIGTERM:
 				a.Stop()
-			case unix.SIGPIPE, unix.SIGHUP:
+			case unix.SIGHUP:
 				// Noop
 			case unix.SIGINFO:
 				stacklen := runtime.Stack(buf, true)

--- a/internal/agent/sighndlr_linux.go
+++ b/internal/agent/sighndlr_linux.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (a *Agent) signalNotifySetup() {
-	signal.Notify(a.signalCh, os.Interrupt, unix.SIGTERM, unix.SIGHUP, unix.SIGPIPE, unix.SIGTRAP)
+	signal.Notify(a.signalCh, os.Interrupt, unix.SIGTERM, unix.SIGHUP, unix.SIGTRAP)
 }
 
 // handleSignals runs the signal handler thread.
@@ -39,7 +39,7 @@ func (a *Agent) handleSignals() error {
 			switch sig {
 			case os.Interrupt, unix.SIGTERM:
 				a.Stop()
-			case unix.SIGPIPE, unix.SIGHUP:
+			case unix.SIGHUP:
 				// Noop
 			case unix.SIGTRAP:
 				stacklen := runtime.Stack(buf, true)

--- a/internal/agent/sighndlr_windows.go
+++ b/internal/agent/sighndlr_windows.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (a *Agent) signalNotifySetup() {
-	signal.Notify(a.signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGPIPE, syscall.SIGTRAP)
+	signal.Notify(a.signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGTRAP)
 }
 
 // handleSignals runs the signal handler thread.
@@ -39,7 +39,7 @@ func (a *Agent) handleSignals() error {
 			switch sig {
 			case os.Interrupt, syscall.SIGTERM:
 				a.Stop()
-			case syscall.SIGPIPE, syscall.SIGHUP:
+			case syscall.SIGHUP:
 				// Noop
 			case syscall.SIGTRAP:
 				stacklen := runtime.Stack(buf, true)

--- a/internal/builtins/builtins.go
+++ b/internal/builtins/builtins.go
@@ -167,7 +167,7 @@ func (b *Builtins) Flush(id string) *cgm.Metrics {
 	defer b.Unlock()
 
 	if err := appstats.SetString("builtins.last_flush", time.Now().String()); err != nil {
-		b.logger.Warn().Err(err).Msg("setting app stat")
+		b.logger.Warn().Err(err).Str("id", id).Msg("setting app stat")
 	}
 
 	metrics := cgm.Metrics{}

--- a/internal/builtins/builtins_test.go
+++ b/internal/builtins/builtins_test.go
@@ -32,7 +32,7 @@ type foo struct {
 func newFoo() collector.Collector {
 	return &foo{id: "foo"}
 }
-func (f *foo) Collect(ctx context.Context) error {
+func (f *foo) Collect(_ context.Context) error {
 	f.Lock()
 	defer f.Unlock()
 	f.lastStart = time.Now()

--- a/internal/builtins/collector/generic/collector.go
+++ b/internal/builtins/collector/generic/collector.go
@@ -34,7 +34,7 @@ type gencommon struct {
 }
 
 // Collect returns collector metrics.
-func (c *gencommon) Collect(ctx context.Context) error {
+func (c *gencommon) Collect(_ context.Context) error {
 	c.Lock()
 	defer c.Unlock()
 	return collector.ErrNotImplemented

--- a/internal/builtins/collector/generic/load.go
+++ b/internal/builtins/collector/generic/load.go
@@ -17,7 +17,6 @@ import (
 	"github.com/circonus-labs/circonus-agent/internal/tags"
 	cgm "github.com/circonus-labs/circonus-gometrics/v3"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v3/load"
 )
 
@@ -38,7 +37,7 @@ func NewLoadCollector(cfgBaseName string, parentLogger zerolog.Logger) (collecto
 	c := Load{}
 	c.id = NameLoad
 	c.pkgID = PackageName + "." + c.id
-	c.logger = log.With().Str("pkg", PackageName).Str("id", c.id).Logger()
+	c.logger = parentLogger.With().Str("pkg", PackageName).Str("id", c.id).Logger()
 	c.baseTags = tags.FromList(tags.GetBaseTags())
 
 	var opts loadOptions

--- a/internal/builtins/collector/linux/procfs/collector.go
+++ b/internal/builtins/collector/linux/procfs/collector.go
@@ -64,7 +64,7 @@ func newCommon(id, procFSPath, procFile string, baseTags cgm.Tags) common {
 }
 
 // Collect returns collector metrics.
-func (c *common) Collect(ctx context.Context) error {
+func (c *common) Collect(_ context.Context) error {
 	c.Lock()
 	defer c.Unlock()
 	return collector.ErrNotImplemented
@@ -185,7 +185,7 @@ func (c *common) readFile(file string) ([]string, error) {
 		lines = append(lines, s.Text())
 	}
 	if err := s.Err(); err != nil {
-		return lines, fmt.Errorf("scanner: %w [close:%v]", err, f.Close())
+		return lines, fmt.Errorf("scanner: %w [close:%v]", err, f.Close()) //nolint:errorlint
 	}
 
 	return lines, f.Close() //nolint:wrapcheck

--- a/internal/builtins/collector/linux/procfs/cpu.go
+++ b/internal/builtins/collector/linux/procfs/cpu.go
@@ -159,6 +159,10 @@ func (c *CPU) Collect(ctx context.Context) error {
 	_ = c.addMetric(&metrics, "", "num_cpu", "I", runtime.NumCPU(), tags.Tags{})
 
 	for _, line := range lines {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		fields := strings.Fields(line)
 
 		switch fields[0] {

--- a/internal/builtins/collector/linux/procfs/disk.go
+++ b/internal/builtins/collector/linux/procfs/disk.go
@@ -181,6 +181,9 @@ func (c *Disk) Collect(ctx context.Context) error {
 		return fmt.Errorf("%s read file: %w", c.pkgID, err)
 	}
 	for _, line := range lines {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
 		fields := strings.Fields(line)
 
 		//  0 major                ignore
@@ -225,6 +228,9 @@ func (c *Disk) Collect(ctx context.Context) error {
 	mdrx := regexp.MustCompile(`^md[0-9]+`)
 	metricType := "L" // uint64
 	for devID, devStats := range stats {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
 
 		if c.exclude.MatchString(devID) || !c.include.MatchString(devID) {
 			c.logger.Debug().Str("device", devID).Msg("excluded device name, ignoring")

--- a/internal/builtins/collector/linux/procfs/load.go
+++ b/internal/builtins/collector/linux/procfs/load.go
@@ -131,6 +131,10 @@ func (c *Load) Collect(ctx context.Context) error {
 		}
 
 		for _, line := range lines {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
+
 			fields := strings.Fields(line)
 
 			if len(fields) < 3 {
@@ -141,21 +145,21 @@ func (c *Load) Collect(ctx context.Context) error {
 			if v, err := strconv.ParseFloat(fields[0], 64); err != nil {
 				c.logger.Warn().Err(err).Msg("parsing 1min field")
 				continue
-			} else {
+			} else { //nolint:revive
 				_ = c.addMetric(&metrics, "", "load_1min", metricType, v, tagList)
 			}
 
 			if v, err := strconv.ParseFloat(fields[1], 64); err != nil {
 				c.logger.Warn().Err(err).Msg("parsing 5min field")
 				continue
-			} else {
+			} else { //nolint:revive
 				_ = c.addMetric(&metrics, "", "load_5min", metricType, v, tagList)
 			}
 
 			if v, err := strconv.ParseFloat(fields[2], 64); err != nil {
 				c.logger.Warn().Err(err).Msg("parsing 15min field")
 				continue
-			} else {
+			} else { //nolint:revive
 				_ = c.addMetric(&metrics, "", "load_15min", metricType, v, tagList)
 			}
 		}
@@ -173,6 +177,9 @@ func (c *Load) Collect(ctx context.Context) error {
 		}
 
 		for _, line := range lines {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
 			var lineErr error
 			fields := strings.Fields(line)
 

--- a/internal/builtins/collector/linux/procfs/net_socket.go
+++ b/internal/builtins/collector/linux/procfs/net_socket.go
@@ -135,7 +135,7 @@ func (c *NetSocket) Collect(ctx context.Context) error {
 	c.lastStart = time.Now()
 	c.Unlock()
 
-	if err := c.sockstatCollect(&metrics); err != nil {
+	if err := c.sockstatCollect(ctx, &metrics); err != nil {
 		c.logger.Warn().Err(err).Msg("sockstat")
 	}
 
@@ -149,7 +149,7 @@ func (c *NetSocket) Collect(ctx context.Context) error {
 // }
 
 // sockstatCollect gets metrics from /proc/net/sockstat and /proc/net/sockstat6.
-func (c *NetSocket) sockstatCollect(metrics *cgm.Metrics) error {
+func (c *NetSocket) sockstatCollect(ctx context.Context, metrics *cgm.Metrics) error {
 
 	tagUnitsConnections := tags.Tag{Category: "units", Value: "connections"}
 	metricType := "l" // int64
@@ -176,6 +176,9 @@ func (c *NetSocket) sockstatCollect(metrics *cgm.Metrics) error {
 		// stats := make(map[string][]rawSocketStat)
 
 		for _, l := range lines {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
 			line := strings.TrimSpace(l)
 			fields := strings.Fields(line)
 

--- a/internal/builtins/collector/linux/procfs/procfs.go
+++ b/internal/builtins/collector/linux/procfs/procfs.go
@@ -142,3 +142,12 @@ func New(ctx context.Context) ([]collector.Collector, error) {
 
 	return collectors, nil
 }
+
+func done(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/builtins/collector/windows/nvidia/collector.go
+++ b/internal/builtins/collector/windows/nvidia/collector.go
@@ -25,7 +25,7 @@ import (
 // collector implementation requires it.
 
 // Collect metrics.
-func (c *common) Collect(ctx context.Context) error {
+func (c *common) Collect(_ context.Context) error {
 	c.Lock()
 	defer c.Unlock()
 	return collector.ErrNotImplemented

--- a/internal/builtins/collector/windows/wmi/cache.go
+++ b/internal/builtins/collector/windows/wmi/cache.go
@@ -164,6 +164,10 @@ func (c *Cache) Collect(ctx context.Context) error {
 	}
 
 	for _, item := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		_ = c.addMetric(&metrics, "", "AsyncCopyReadsPersec", metricType, item.AsyncCopyReadsPersec, cgm.Tags{tagUnitsOperations})
 		_ = c.addMetric(&metrics, "", "AsyncDataMapsPersec", metricType, item.AsyncDataMapsPersec, cgm.Tags{tagUnitsOperations})
 		_ = c.addMetric(&metrics, "", "AsyncFastReadsPersec", metricType, item.AsyncFastReadsPersec, cgm.Tags{tagUnitsOperations})

--- a/internal/builtins/collector/windows/wmi/collector.go
+++ b/internal/builtins/collector/windows/wmi/collector.go
@@ -28,7 +28,7 @@ import (
 // collector implementation requires it.
 
 // Collect metrics.
-func (c *wmicommon) Collect(ctx context.Context) error {
+func (c *wmicommon) Collect(_ context.Context) error {
 	c.Lock()
 	defer c.Unlock()
 	return collector.ErrNotImplemented

--- a/internal/builtins/collector/windows/wmi/memory.go
+++ b/internal/builtins/collector/windows/wmi/memory.go
@@ -164,6 +164,10 @@ func (c *Memory) Collect(ctx context.Context) error {
 	}
 
 	for _, item := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		_ = c.addMetric(&metrics, "", "AvailableBytes", metricType, item.AvailableBytes, cgm.Tags{tagUnitsBytes})
 		_ = c.addMetric(&metrics, "", "CacheBytes", metricType, item.CacheBytes, cgm.Tags{tagUnitsBytes})
 		_ = c.addMetric(&metrics, "", "CacheFaultsPersec", metricType, item.CacheFaultsPersec, cgm.Tags{})

--- a/internal/builtins/collector/windows/wmi/network_interface.go
+++ b/internal/builtins/collector/windows/wmi/network_interface.go
@@ -180,6 +180,10 @@ func (c *NetInterface) Collect(ctx context.Context) error {
 	tagUnitsPackets := cgm.Tag{Category: "units", Value: "packets"}
 
 	for _, ifMetrics := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		ifName := c.cleanName(ifMetrics.Name)
 		if c.exclude.MatchString(ifName) || !c.include.MatchString(ifName) {
 			continue

--- a/internal/builtins/collector/windows/wmi/network_ip.go
+++ b/internal/builtins/collector/windows/wmi/network_ip.go
@@ -199,6 +199,10 @@ func (c *NetIP) Collect(ctx context.Context) error {
 		protoTag := cgm.Tag{Category: "network-proto", Value: "ip4"}
 
 		for _, item := range dst {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
+
 			_ = c.addMetric(&metrics, "", "DatagramsForwardedPersec", metricType, item.DatagramsForwardedPersec, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsOutboundDiscarded", metricType, item.DatagramsOutboundDiscarded, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsOutboundNoRoute", metricType, item.DatagramsOutboundNoRoute, cgm.Tags{protoTag, tagUnitsDatagrams})
@@ -235,6 +239,10 @@ func (c *NetIP) Collect(ctx context.Context) error {
 		protoTag := cgm.Tag{Category: "network-proto", Value: "ip6"}
 
 		for _, item := range dst {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
+
 			_ = c.addMetric(&metrics, "", "DatagramsForwardedPersec", metricType, item.DatagramsForwardedPersec, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsOutboundDiscarded", metricType, item.DatagramsOutboundDiscarded, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsOutboundNoRoute", metricType, item.DatagramsOutboundNoRoute, cgm.Tags{protoTag, tagUnitsDatagrams})

--- a/internal/builtins/collector/windows/wmi/network_tcp.go
+++ b/internal/builtins/collector/windows/wmi/network_tcp.go
@@ -183,6 +183,10 @@ func (c *NetTCP) Collect(ctx context.Context) error {
 		protoTag := cgm.Tag{Category: "network-proto", Value: "tcp4"}
 
 		for _, item := range dst {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
+
 			_ = c.addMetric(&metrics, "", "ConnectionFailures", metricType, item.ConnectionFailures, cgm.Tags{protoTag, tagUnitsConnections})
 			_ = c.addMetric(&metrics, "", "ConnectionsActive", metricType, item.ConnectionsActive, cgm.Tags{protoTag, tagUnitsConnections})
 			_ = c.addMetric(&metrics, "", "ConnectionsEstablished", metricType, item.ConnectionsEstablished, cgm.Tags{protoTag, tagUnitsConnections})
@@ -211,6 +215,10 @@ func (c *NetTCP) Collect(ctx context.Context) error {
 		protoTag := cgm.Tag{Category: "network-proto", Value: "tcp6"}
 
 		for _, item := range dst {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
+
 			_ = c.addMetric(&metrics, "", "ConnectionFailures", metricType, item.ConnectionFailures, cgm.Tags{protoTag, tagUnitsConnections})
 			_ = c.addMetric(&metrics, "", "ConnectionsActive", metricType, item.ConnectionsActive, cgm.Tags{protoTag, tagUnitsConnections})
 			_ = c.addMetric(&metrics, "", "ConnectionsEstablished", metricType, item.ConnectionsEstablished, cgm.Tags{protoTag, tagUnitsConnections})

--- a/internal/builtins/collector/windows/wmi/network_udp.go
+++ b/internal/builtins/collector/windows/wmi/network_udp.go
@@ -174,6 +174,10 @@ func (c *NetUDP) Collect(ctx context.Context) error {
 		protoTag := cgm.Tag{Category: "network-proto", Value: "udp4"}
 
 		for _, item := range dst {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
+
 			_ = c.addMetric(&metrics, "", "DatagramsNoPortPersec", metricType, item.DatagramsNoPortPersec, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsPersec", metricType, item.DatagramsPersec, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsReceivedErrors", metricType, item.DatagramsReceivedErrors, cgm.Tags{protoTag, tagUnitsDatagrams})
@@ -198,6 +202,10 @@ func (c *NetUDP) Collect(ctx context.Context) error {
 		protoTag := cgm.Tag{Category: "network-proto", Value: "udp6"}
 
 		for _, item := range dst {
+			if done(ctx) {
+				return fmt.Errorf("context: %w", ctx.Err())
+			}
+
 			_ = c.addMetric(&metrics, "", "DatagramsNoPortPersec", metricType, item.DatagramsNoPortPersec, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsPersec", metricType, item.DatagramsPersec, cgm.Tags{protoTag, tagUnitsDatagrams})
 			_ = c.addMetric(&metrics, "", "DatagramsReceivedErrors", metricType, item.DatagramsReceivedErrors, cgm.Tags{protoTag, tagUnitsDatagrams})

--- a/internal/builtins/collector/windows/wmi/objects.go
+++ b/internal/builtins/collector/windows/wmi/objects.go
@@ -133,6 +133,10 @@ func (c *Objects) Collect(ctx context.Context) error {
 
 	metricType := "I"
 	for _, item := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		_ = c.addMetric(&metrics, "", "Events", metricType, item.Events, cgm.Tags{})
 		_ = c.addMetric(&metrics, "", "Mutexes", metricType, item.Mutexes, cgm.Tags{})
 		_ = c.addMetric(&metrics, "", "Processes", metricType, item.Processes, cgm.Tags{})

--- a/internal/builtins/collector/windows/wmi/paging_file.go
+++ b/internal/builtins/collector/windows/wmi/paging_file.go
@@ -155,6 +155,10 @@ func (c *PagingFile) Collect(ctx context.Context) error {
 	metricType := "I"
 	tagUnitsPercent := cgm.Tag{Category: "units", Value: "percent"}
 	for _, item := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		itemName := c.cleanName(item.Name)
 		if c.exclude.MatchString(itemName) || !c.include.MatchString(itemName) {
 			continue

--- a/internal/builtins/collector/windows/wmi/processes.go
+++ b/internal/builtins/collector/windows/wmi/processes.go
@@ -187,6 +187,10 @@ func (c *Processes) Collect(ctx context.Context) error {
 	tagUnitsOperations := cgm.Tag{Category: "units", Value: "operations"}
 	tagUnitsPercent := cgm.Tag{Category: "units", Value: "percent"}
 	for _, item := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		itemName := c.cleanName(item.Name)
 		if c.exclude.MatchString(itemName) || !c.include.MatchString(itemName) {
 			continue

--- a/internal/builtins/collector/windows/wmi/processor.go
+++ b/internal/builtins/collector/windows/wmi/processor.go
@@ -159,6 +159,10 @@ func (c *Processor) Collect(ctx context.Context) error {
 	metricType := "L"
 	tagUnitsPercent := cgm.Tag{Category: "units", Value: "percent"}
 	for _, item := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		cpuID := c.cleanName(item.Name)
 
 		metricSuffix := ""

--- a/internal/builtins/collector/windows/wmi/system.go
+++ b/internal/builtins/collector/windows/wmi/system.go
@@ -154,6 +154,10 @@ func (c *System) Collect(ctx context.Context) error {
 	metricType := "L"
 	tagUnitsPercent := cgm.Tag{Category: "units", Value: "percent"}
 	for _, item := range dst {
+		if done(ctx) {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+
 		_ = c.addMetric(&metrics, "", "AlignmentFixupsPerSec", metricType, item.AlignmentFixupsPerSec, cgm.Tags{})
 		_ = c.addMetric(&metrics, "", "ContextSwitchesPerSec", metricType, item.ContextSwitchesPerSec, cgm.Tags{})
 		_ = c.addMetric(&metrics, "", "ExceptionDispatchesPerSec", metricType, item.ExceptionDispatchesPerSec, cgm.Tags{})

--- a/internal/builtins/collector/windows/wmi/wmi.go
+++ b/internal/builtins/collector/windows/wmi/wmi.go
@@ -9,6 +9,7 @@
 package wmi
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"regexp"
@@ -217,4 +218,14 @@ func New() ([]collector.Collector, error) {
 	}
 
 	return collectors, nil
+}
+
+func done(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+
 }

--- a/internal/builtins/configure.go
+++ b/internal/builtins/configure.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (b *Builtins) configure(ctx context.Context) error {
+func (b *Builtins) configure(_ context.Context) error {
 	l := log.With().Str("pkg", "builtins").Logger()
 
 	l.Debug().Msg("calling generic.New")

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -284,10 +284,7 @@ func (c *Check) RefreshReverseConfig() error {
 	if err := c.FetchBrokerConfig(); err != nil {
 		return err
 	}
-	if err := c.setReverseConfigs(); err != nil {
-		return err
-	}
-	return nil
+	return c.setReverseConfigs()
 }
 
 // GetReverseConfigs returns the reverse connection configuration(s) to use for the check.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ type StatsDGroup struct {
 type StatsD struct {
 	Group              StatsDGroup `json:"group" yaml:"group" toml:"group"`
 	Host               StatsDHost  `json:"host" yaml:"host" toml:"host"`
-	Addr               string      `join:"addr" yaml:"addr" toml:"addr"`
+	Addr               string      `json:"addr" yaml:"addr" toml:"addr"`
 	Port               string      `json:"port" yaml:"port" toml:"port"`
 	NPP                uint        `json:"npp" yaml:"npp" toml:"npp"`
 	PQS                uint        `json:"pqs" yaml:"pqs" toml:"pqs"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,13 +98,14 @@ type StatsDGroup struct {
 
 // StatsD defines the running config.statsd structure.
 type StatsD struct {
-	Group    StatsDGroup `json:"group" yaml:"group" toml:"group"`
-	Host     StatsDHost  `json:"host" yaml:"host" toml:"host"`
-	Addr     string      `join:"addr" yaml:"addr" toml:"addr"`
-	Port     string      `json:"port" yaml:"port" toml:"port"`
-	NPP      uint        `json:"npp" yaml:"npp" toml:"npp"`
-	PQS      uint        `json:"pqs" yaml:"pqs" toml:"pqs"`
-	Disabled bool        `json:"disabled" yaml:"disabled" toml:"disabled"`
+	Group              StatsDGroup `json:"group" yaml:"group" toml:"group"`
+	Host               StatsDHost  `json:"host" yaml:"host" toml:"host"`
+	Addr               string      `join:"addr" yaml:"addr" toml:"addr"`
+	Port               string      `json:"port" yaml:"port" toml:"port"`
+	NPP                uint        `json:"npp" yaml:"npp" toml:"npp"`
+	PQS                uint        `json:"pqs" yaml:"pqs" toml:"pqs"`
+	Disabled           bool        `json:"disabled" yaml:"disabled" toml:"disabled"`
+	DebugMetricParsing bool        `mapstructure:"debug_metric_parsing" json:"debug_metric_parsing" toml:"debug_metrics_parsing" yaml:"debug_metric_parsing"`
 }
 
 // Thresholds defines triggers used to include metrics.
@@ -156,7 +157,6 @@ const (
 
 	// KeyDebug enables debug messages.
 	KeyDebug = "debug"
-
 	// KeyDebugCGM enables debug messages for circonus-gometrics.
 	KeyDebugCGM = "debug_cgm"
 
@@ -271,6 +271,9 @@ const (
 
 	// KeyStatsdPQS sets packet queue size.
 	KeyStatsdPQS = "statsd.pqs"
+
+	// KeyStatsdDebugMetricParsing controls verbose logging of metric parsing results.
+	KeyStatsdDebugMetricParsing = "statsd.debug_metric_parsing"
 
 	// KeyCollectors defines the builtin collectors to enable.
 	KeyCollectors = "collectors"

--- a/internal/multiagent/multiagent.go
+++ b/internal/multiagent/multiagent.go
@@ -37,11 +37,11 @@ type Metric struct {
 }
 
 type TrapResult struct {
-	CheckUUID  string
-	Error      string `json:"error,omitempty"`
-	SubmitUUID uuid.UUID
-	Filtered   uint64 `json:"filtered,omitempty"`
-	Stats      uint64 `json:"stats"`
+	CheckUUID  string    `json:"-"`
+	Error      string    `json:"error,omitempty"`
+	SubmitUUID uuid.UUID `json:"-"`
+	Filtered   uint64    `json:"filtered,omitempty"`
+	Stats      uint64    `json:"stats"`
 }
 
 type Submitter struct {

--- a/internal/server/agent_mem_stats_windows.go
+++ b/internal/server/agent_mem_stats_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 // agentMemoryStats produces the internal agent metrics.
-func (s *Server) agentMemoryStats(metrics cgm.Metrics, mtags []string) {
+func (s *Server) agentMemoryStats(_ cgm.Metrics, _ []string) {
 	// var mem syscall.Rusage
 	// if err := syscall.Getrusage(syscall.RUSAGE_SELF, &mem); err == nil {
 	// 	metrics[tags.MetricNameWithStreamTags("agent_max_rss", tags.FromList(ctags))] = cgm.Metric{Value: uint64(mem.Maxrss * 1024), Type: "L"} // maximum resident set size used (in kilobytes)

--- a/internal/server/receiver/receiver.go
+++ b/internal/server/receiver/receiver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/circonus-labs/circonus-agent/internal/release"
 	"github.com/circonus-labs/circonus-agent/internal/tags"
 	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+	"github.com/openhistogram/circonusllhist"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -29,13 +30,15 @@ var (
 	metrics          *cgm.CirconusMetrics
 	baseTags         []string
 	histogramRx      *regexp.Regexp // encoded histogram regular express (e.g. coming from a cgm put to /write)
+	numFloatRx       *regexp.Regexp // is number or float
 	histogramRxNames []string
 	logger           = log.With().Str("pkg", "receiver").Logger()
 )
 
 func init() {
-	histogramRx = regexp.MustCompile(`^H\[(?P<bucket>[^\]]+)\]=(?P<count>[0-9]+)$`)
+	histogramRx = regexp.MustCompile(`H\[(?P<bucket>[^\]]+)\]=(?P<count>[0-9]+)`)
 	histogramRxNames = histogramRx.SubexpNames()
+	numFloatRx = regexp.MustCompile(`^[0-9][0-9]*(\.[0-9]+)?$`)
 }
 
 // logshim is used to satisfy apiclient Logger interface (avoiding ptr receiver issue).
@@ -132,22 +135,29 @@ func Parse(id string, data io.Reader) error {
 				metrics.AddGaugeWithTags(metricName, metricTags, *v)
 			}
 		case "h":
-			fallthrough
-		case "n":
-			v, isHist := parseFloat(metricName, metric)
-			if v != nil {
-				metrics.AddGaugeWithTags(metricName, metricTags, *v)
-			} else if isHist {
-				samples := parseHistogram(metricName, metric)
-				if samples != nil && len(*samples) > 0 {
-					for _, sample := range *samples {
-						if sample.bucket {
-							metrics.RecordCountForValueWithTags(metricName, metricTags, sample.value, sample.count)
-						} else {
-							metrics.RecordValueWithTags(metricName, metricTags, sample.value)
-						}
+			switch metric.Value.(type) { // nolint:gocritic
+			case string:
+				// convert to []interface{} which is what histogram parser expects
+				v := make([]interface{}, 1)
+				v[0] = metric.Value.(string)
+				metric.Value = v
+			default:
+			}
+			fmt.Printf("sending histogram: %v\n", metric)
+			samples := parseHistogram(metricName, metric)
+			if samples != nil && len(*samples) > 0 {
+				for _, sample := range *samples {
+					if sample.bucket {
+						metrics.RecordCountForValueWithTags(metricName, metricTags, sample.value, sample.count)
+					} else {
+						metrics.RecordValueWithTags(metricName, metricTags, sample.value)
 					}
 				}
+			}
+		case "n":
+			v := parseFloat(metricName, metric)
+			if v != nil {
+				metrics.AddGaugeWithTags(metricName, metricTags, *v)
 			}
 		case "s":
 			metrics.SetTextWithTags(metricName, metricTags, fmt.Sprintf("%v", metric.Value))
@@ -263,18 +273,16 @@ func parseUint64(metricName string, metric tags.JSONMetric) *uint64 {
 	return nil
 }
 
-func parseFloat(metricName string, metric tags.JSONMetric) (*float64, bool) {
+func parseFloat(metricName string, metric tags.JSONMetric) *float64 {
 	switch t := metric.Value.(type) {
 	case float64:
 		v := metric.Value.(float64)
-		return &v, false
-	case []interface{}: // treat as histogram
-		return nil, true
+		return &v
 	case string:
 		v, err := strconv.ParseFloat(metric.Value.(string), 64)
 		if err == nil {
 			v2 := v
-			return &v2, false
+			return &v2
 		}
 		logger.Error().
 			Str("metric", metricName).
@@ -288,7 +296,7 @@ func parseFloat(metricName string, metric tags.JSONMetric) (*float64, bool) {
 			Str("type", fmt.Sprintf("%T", t)).
 			Msg("invalid value type for metric type")
 	}
-	return nil, false
+	return nil
 }
 
 type histSample struct {
@@ -307,7 +315,10 @@ func parseHistogram(metricName string, metric tags.JSONMetric) *[]histSample {
 				ret = append(ret, histSample{bucket: false, value: v.(float64)})
 			case string:
 				sv := v.(string)
-				if !strings.Contains(sv, "H[") {
+				switch {
+				case strings.Contains(sv, "H["):
+				// nothing, let the code below parse it
+				case numFloatRx.MatchString(sv):
 					v2, err := strconv.ParseFloat(sv, 64)
 					if err != nil {
 						logger.Error().
@@ -320,15 +331,29 @@ func parseHistogram(metricName string, metric tags.JSONMetric) *[]histSample {
 					}
 					ret = append(ret, histSample{bucket: false, value: v2})
 					continue
+				default:
+					// try to parse a serialized histogram
+					raw := []byte(`"` + sv + `"`)
+					var h circonusllhist.Histogram
+					if err := json.Unmarshal(raw, &h); err != nil {
+						logger.Error().
+							Str("metric", metricName).
+							Interface("value", v).
+							Int("position", idx).
+							Err(err).
+							Msg("parsing serialized histogram")
+						continue
+					}
+					sv = strings.Join(h.DecStrings(), " ")
 				}
 
 				//
 				// it's an encoded histogram sample H[value]=count
 				//
-				bucket := ""
-				count := ""
 				matches := histogramRx.FindAllStringSubmatch(sv, -1)
 				for _, match := range matches {
+					bucket := ""
+					count := ""
 					for idx, val := range match {
 						switch histogramRxNames[idx] {
 						case "bucket":
@@ -337,36 +362,36 @@ func parseHistogram(metricName string, metric tags.JSONMetric) *[]histSample {
 							count = val
 						}
 					}
+					if bucket == "" || count == "" {
+						logger.Error().
+							Str("metric", metricName).
+							Str("sample", sv).
+							Int("position", idx).
+							Msg("invalid encoded histogram sample")
+						continue
+					}
+					b, err := strconv.ParseFloat(bucket, 64)
+					if err != nil {
+						logger.Error().
+							Str("metric", metricName).
+							Str("sample", sv).
+							Int("position", idx).
+							Err(err).
+							Msg("encoded histogram sample, value parse")
+						continue
+					}
+					c, err := strconv.ParseInt(count, 10, 64)
+					if err != nil {
+						logger.Error().
+							Str("metric", metricName).
+							Str("sample", sv).
+							Int("position", idx).
+							Err(err).
+							Msg("encoded histogram sample, count parse")
+						continue
+					}
+					ret = append(ret, histSample{bucket: true, value: b, count: c})
 				}
-				if bucket == "" || count == "" {
-					logger.Error().
-						Str("metric", metricName).
-						Str("sample", sv).
-						Int("position", idx).
-						Msg("invalid encoded histogram sample")
-					continue
-				}
-				b, err := strconv.ParseFloat(bucket, 64)
-				if err != nil {
-					logger.Error().
-						Str("metric", metricName).
-						Str("sample", sv).
-						Int("position", idx).
-						Err(err).
-						Msg("encoded histogram sample, value parse")
-					continue
-				}
-				c, err := strconv.ParseInt(count, 10, 64)
-				if err != nil {
-					logger.Error().
-						Str("metric", metricName).
-						Str("sample", sv).
-						Int("position", idx).
-						Err(err).
-						Msg("encoded histogram sample, count parse")
-					continue
-				}
-				ret = append(ret, histSample{bucket: true, value: b, count: c})
 			default:
 				logger.Error().
 					Str("metric", metricName).

--- a/internal/server/receiver/receiver.go
+++ b/internal/server/receiver/receiver.go
@@ -143,7 +143,6 @@ func Parse(id string, data io.Reader) error {
 				metric.Value = v
 			default:
 			}
-			fmt.Printf("sending histogram: %v\n", metric)
 			samples := parseHistogram(metricName, metric)
 			if samples != nil && len(*samples) > 0 {
 				for _, sample := range *samples {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -9,6 +9,7 @@ import (
 	"expvar"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/circonus-labs/circonus-agent/internal/config"
@@ -42,6 +43,8 @@ func (s *Server) router(w http.ResponseWriter, r *http.Request) {
 			expvar.Handler().ServeHTTP(w, r)
 		case promPathRx.MatchString(r.URL.Path): // output prom format...
 			s.promOutput(w)
+		case strings.HasPrefix(r.URL.Path, "/options"):
+			s.handleOptions(w, r)
 		default:
 			_ = appstats.IncrementInt("server.requests_bad")
 			s.logger.Warn().Str("method", r.Method).Str("url", r.URL.String()).Msg("not found")

--- a/internal/statsd/metrics.go
+++ b/internal/statsd/metrics.go
@@ -149,15 +149,17 @@ func (s *Server) parseMetric(metric string) error {
 	tagList = append(tagList, metricTagList...)
 	metricTags := tags.FromList(tagList)
 
-	s.logger.Debug().
-		Str("destination", metricDest).
-		Str("metric", metric).
-		Str("name", metricName).
-		Str("type", metricType).
-		Str("value", metricValue).
-		Float64("rate", sampleRate).
-		Strs("mtags", metricTagList).
-		Msg("parsed")
+	if s.debugMetricParsing {
+		s.logger.Debug().
+			Str("destination", metricDest).
+			Str("metric", metric).
+			Str("name", metricName).
+			Str("type", metricType).
+			Str("value", metricValue).
+			Float64("rate", sampleRate).
+			Strs("mtags", metricTagList).
+			Msg("parsed")
+	}
 
 	switch metricType {
 	case "c": // counter

--- a/internal/statsd/statsd.go
+++ b/internal/statsd/statsd.go
@@ -64,6 +64,7 @@ type Server struct {
 	enableUDPListener     bool // NOTE: defaults to TRUE; uses !disabled (not really a separate option)
 	enableTCPListener     bool // NOTE: defaults to FALSE
 	debugCGM              bool
+	debugMetricParsing    bool
 	groupMetricsmu        sync.Mutex
 	hostMetricsmu         sync.Mutex
 	sync.Mutex
@@ -97,27 +98,28 @@ func New(ctx context.Context) (*Server, error) {
 	g, gctx := errgroup.WithContext(ctx)
 
 	s = Server{
-		group:             g,
-		groupCtx:          gctx,
-		disabled:          viper.GetBool(config.KeyStatsdDisabled),
-		logger:            log.With().Str("pkg", "statsd").Logger(),
-		hostPrefix:        viper.GetString(config.KeyStatsdHostPrefix),
-		hostCategory:      viper.GetString(config.KeyStatsdHostCategory),
-		groupCID:          viper.GetString(config.KeyStatsdGroupCID),
-		groupPrefix:       viper.GetString(config.KeyStatsdGroupPrefix),
-		groupCounterOp:    viper.GetString(config.KeyStatsdGroupCounters),
-		groupGaugeOp:      viper.GetString(config.KeyStatsdGroupGauges),
-		groupSetOp:        viper.GetString(config.KeyStatsdGroupSets),
-		debugCGM:          viper.GetBool(config.KeyDebugCGM),
-		apiKey:            viper.GetString(config.KeyAPITokenKey),
-		apiApp:            viper.GetString(config.KeyAPITokenApp),
-		apiURL:            viper.GetString(config.KeyAPIURL),
-		apiCAFile:         viper.GetString(config.KeyAPICAFile),
-		baseTags:          tags.GetBaseTags(),
-		tcpConnections:    map[string]*net.TCPConn{},
-		tcpMaxConnections: viper.GetUint(config.KeyStatsdMaxTCPConns),
-		npp:               viper.GetUint(config.KeyStatsdNPP),
-		pqs:               viper.GetUint(config.KeyStatsdPQS),
+		group:              g,
+		groupCtx:           gctx,
+		disabled:           viper.GetBool(config.KeyStatsdDisabled),
+		logger:             log.With().Str("pkg", "statsd").Logger(),
+		hostPrefix:         viper.GetString(config.KeyStatsdHostPrefix),
+		hostCategory:       viper.GetString(config.KeyStatsdHostCategory),
+		groupCID:           viper.GetString(config.KeyStatsdGroupCID),
+		groupPrefix:        viper.GetString(config.KeyStatsdGroupPrefix),
+		groupCounterOp:     viper.GetString(config.KeyStatsdGroupCounters),
+		groupGaugeOp:       viper.GetString(config.KeyStatsdGroupGauges),
+		groupSetOp:         viper.GetString(config.KeyStatsdGroupSets),
+		debugCGM:           viper.GetBool(config.KeyDebugCGM),
+		debugMetricParsing: viper.GetBool(config.KeyStatsdDebugMetricParsing),
+		apiKey:             viper.GetString(config.KeyAPITokenKey),
+		apiApp:             viper.GetString(config.KeyAPITokenApp),
+		apiURL:             viper.GetString(config.KeyAPIURL),
+		apiCAFile:          viper.GetString(config.KeyAPICAFile),
+		baseTags:           tags.GetBaseTags(),
+		tcpConnections:     map[string]*net.TCPConn{},
+		tcpMaxConnections:  viper.GetUint(config.KeyStatsdMaxTCPConns),
+		npp:                viper.GetUint(config.KeyStatsdNPP),
+		pqs:                viper.GetUint(config.KeyStatsdPQS),
 	}
 
 	if s.npp == 0 {
@@ -336,8 +338,8 @@ func (s *Server) initGroupMetrics() error {
 	cmc := &cgm.Config{}
 	if s.debugCGM {
 		cmc.Debug = s.debugCGM
-		cmc.Log = logshim{logh: s.logger.With().Str("pkg", "cgm.statsd-group-check").Logger()}
 	}
+	cmc.Log = logshim{logh: s.logger.With().Str("pkg", "cgm.statsd-group-check").Logger()}
 	cmc.CheckManager.API.TokenKey = s.apiKey
 	cmc.CheckManager.API.TokenApp = s.apiApp
 	cmc.CheckManager.API.URL = s.apiURL


### PR DESCRIPTION
* fix(receiver): add SerializeB64 handling for histograms to the `/write` endpoint [CUS-87]
* feat: `/options` endpoint to dynamically control log_level (e.g. turn debug on/off while running)
* feat(statsd): explicit metric parsing debug option
* fix: don't swallow sigpipe
* fix(lint): unsed args (generic, linux, & windows)
* chore: golangci-lint v1.52
* fix(lint): exports annotated with json tag
* fix(lint): redundant if-return
* fix(lint): deprecated linters
* fix: installer to correctly use `.` and `_` for rpm and deb urls
* build(deps): bump github.com/rs/zerolog from 1.26.1 to 1.28.0
* build(deps): bump github.com/circonus-labs/go-apiclient from 0.7.17 to 0.7.18
* upd: clean build dir on start, always clone repo
* add: trigger on after up to check Go version
* add: generic Go version checker script
* build(deps): bump golangci/golangci-lint-action from 3.1.0 to 3.2.0


[CUS-87]: https://circonus.atlassian.net/browse/CUS-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ